### PR TITLE
feat(tasks): allow creating tasks without due dates

### DIFF
--- a/e2e/todo-composer.spec.ts
+++ b/e2e/todo-composer.spec.ts
@@ -37,6 +37,24 @@ test.describe('TodoView composer forwards title into modal', () => {
     await expect(titleInput).toHaveValue('Buy milk')
   })
 
+  test('can create a task without a due date', async ({ page }) => {
+    await page.goto('/tasks')
+
+    await page.locator('[data-component="add-task-button"]').click()
+    const composer = page.getByPlaceholder('What needs doing?')
+    await composer.fill('Someday task')
+    await composer.press('Enter')
+
+    const modal = page.locator('[data-component="modal-card"]')
+    await expect(modal).toBeVisible()
+    await modal.locator('[data-component="task-no-due-date"]').check()
+    await modal.locator('[data-component="modal-save"]').click()
+
+    await expect(modal).not.toBeVisible()
+    await expect(page.locator('main').getByText('No due date')).toBeVisible()
+    await expect(page.locator('main').getByText('Someday task')).toBeVisible()
+  })
+
   test('clearing the composer input and pressing Enter does not open the modal', async ({
     page,
   }) => {

--- a/src/features/calendar/components/EventModal.tsx
+++ b/src/features/calendar/components/EventModal.tsx
@@ -483,15 +483,17 @@ export function EventModal(): JSX.Element | null {
     const attachmentsChanged = JSON.stringify(attachments) !== JSON.stringify(existingAttachments)
 
     if (isTaskMode) {
-      const taskDueDate = dueDate || format(parseISO(existingEventForMode.start), 'yyyy-MM-dd')
       const taskTime = dueAllDay ? '00:00:00' : `${dueTime}:00`
-      const currentStart = `${taskDueDate}T${taskTime}`
+      const taskDueDate = dueDate ? (dueAllDay ? dueDate : `${dueDate}T${taskTime}`) : undefined
+      const currentStart = dueDate ? `${dueDate}T${taskTime}` : existingEventForMode.start
       return (
         title !== existingEventForMode.title ||
         description !== (existingEventForMode.description || '') ||
         location !== (existingEventForMode.location || '') ||
         currentStart !== existingEventForMode.start ||
-        dueAllDay !== (existingEventForMode.isAllDay ?? true) ||
+        taskDueDate !== existingEventForMode.dueDate ||
+        (dueDate ? dueAllDay : (existingEventForMode.isAllDay ?? true)) !==
+          (existingEventForMode.isAllDay ?? true) ||
         completed !== (existingEventForMode.completed || false) ||
         priority !== existingEventForMode.priority ||
         parentTaskId !== existingEventForMode.parentTaskId ||
@@ -1221,7 +1223,10 @@ export function EventModal(): JSX.Element | null {
               completed={completed}
               onCompletedChange={setCompleted}
               dueDate={dueDate}
-              onDueDateChange={setDueDate}
+              onDueDateChange={(date) => {
+                setDueDate(date)
+                if (!date) setDueAllDay(true)
+              }}
               dueTime={dueTime}
               onDueTimeChange={setDueTime}
               dueAllDay={dueAllDay}

--- a/src/features/calendar/components/TaskFormFields.tsx
+++ b/src/features/calendar/components/TaskFormFields.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'react'
 import { useRef } from 'react'
+import { format } from 'date-fns'
 import type { CalendarEvent, TaskPriority } from '@/types'
 import { useScrollInput } from '@/hooks/useScrollInput'
 import styles from './EventModal.module.css'
@@ -51,6 +52,7 @@ export function TaskFormFields({
   const dueDateRef = useRef<HTMLInputElement>(null)
   const dueTimeRef = useRef<HTMLInputElement>(null)
   const parentTask = parentTasks.find((task) => task.id === parentTaskId)
+  const hasDueDate = dueDate.trim().length > 0
   useScrollInput([dueDateRef, dueTimeRef])
 
   return (
@@ -71,12 +73,28 @@ export function TaskFormFields({
           <label className={styles.checkbox}>
             <input
               type="checkbox"
-              checked={dueAllDay}
-              onChange={(e) => onDueAllDayChange(e.target.checked)}
+              checked={!hasDueDate}
+              onChange={(e) =>
+                onDueDateChange(e.target.checked ? '' : format(new Date(), 'yyyy-MM-dd'))
+              }
+              data-component="task-no-due-date"
             />
-            <span>Only due date</span>
+            <span>No due date</span>
           </label>
         </div>
+
+        {hasDueDate && (
+          <div className={styles.field}>
+            <label className={styles.checkbox}>
+              <input
+                type="checkbox"
+                checked={dueAllDay}
+                onChange={(e) => onDueAllDayChange(e.target.checked)}
+              />
+              <span>Only due date</span>
+            </label>
+          </div>
+        )}
       </div>
 
       <div className={styles.row} data-component="task-subtasks">
@@ -123,35 +141,38 @@ export function TaskFormFields({
       )}
 
       <div className={styles.row}>
-        <div className={styles.field}>
-          <label className={styles.label} htmlFor="due-date">
-            Due date
-          </label>
-          <input
-            type="date"
-            id="due-date"
-            ref={dueDateRef}
-            value={dueDate.split('T')[0]}
-            onChange={(e) => onDueDateChange(e.target.value)}
-            className={styles.input}
-            required
-          />
-        </div>
+        {hasDueDate && (
+          <>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="due-date">
+                Due date
+              </label>
+              <input
+                type="date"
+                id="due-date"
+                ref={dueDateRef}
+                value={dueDate.split('T')[0]}
+                onChange={(e) => onDueDateChange(e.target.value)}
+                className={styles.input}
+              />
+            </div>
 
-        {!dueAllDay && (
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="due-time">
-              Due time
-            </label>
-            <input
-              type="time"
-              ref={dueTimeRef}
-              id="due-time"
-              value={dueTime}
-              onChange={(e) => onDueTimeChange(e.target.value)}
-              className={styles.input}
-            />
-          </div>
+            {!dueAllDay && (
+              <div className={styles.field}>
+                <label className={styles.label} htmlFor="due-time">
+                  Due time
+                </label>
+                <input
+                  type="time"
+                  ref={dueTimeRef}
+                  id="due-time"
+                  value={dueTime}
+                  onChange={(e) => onDueTimeChange(e.target.value)}
+                  className={styles.input}
+                />
+              </div>
+            )}
+          </>
         )}
 
         <div className={styles.field}>


### PR DESCRIPTION
Calino already identifies and supports tasks without a due date, including rendering them in the “No due date” section. However, the task creation flow always required a due date, so users could not create those tasks from the UI