### PR TITLE
Add sidebar calendar color picker with CalDAV sync

### DIFF
--- a/e2e/sidebar-sections.spec.ts
+++ b/e2e/sidebar-sections.spec.ts
@@ -53,4 +53,44 @@ test.describe('Sidebar sections', () => {
     await expect(categorySection).toHaveAttribute('aria-expanded', 'true')
     await expect(page.getByRole('button', { name: 'Work' })).toBeVisible()
   })
+
+  test('calendar color picker applies a preset color', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'calino-storage',
+        JSON.stringify({
+          state: {
+            calendars: [
+              {
+                id: 'default',
+                name: 'Offline calendar',
+                color: '#4285F4',
+                isVisible: true,
+                isDefault: true,
+                showTasksInViews: true,
+              },
+            ],
+          },
+          version: 1,
+        })
+      )
+    })
+
+    await page.goto('/month')
+    await page.locator('[data-component="calendar-section-toggle"]').click()
+
+    const colorButton = page.getByRole('button', { name: 'Change Offline calendar color' })
+    await colorButton.click()
+    const picker = page.locator('[data-component="calendar-color-picker"]')
+    await expect(picker).toBeVisible()
+    const customColor = picker.getByLabel('Custom color for Offline calendar').locator('..')
+    await expect(customColor).toBeVisible()
+    const firstPreset = picker.getByRole('button', { name: 'Use #4285F4 for Offline calendar' })
+    const [firstPresetBox, customColorBox] = await Promise.all([firstPreset.boundingBox(), customColor.boundingBox()])
+    expect(firstPresetBox?.y).toBe(customColorBox?.y)
+
+    await picker.getByRole('button', { name: 'Use #EA4335 for Offline calendar' }).click()
+    await expect(picker).toBeHidden()
+    await expect(colorButton).toHaveCSS('background-color', 'rgb(234, 67, 53)')
+  })
 })

--- a/e2e/sidebar-sections.spec.ts
+++ b/e2e/sidebar-sections.spec.ts
@@ -93,4 +93,40 @@ test.describe('Sidebar sections', () => {
     await expect(picker).toBeHidden()
     await expect(colorButton).toHaveCSS('background-color', 'rgb(234, 67, 53)')
   })
+
+  test('calendar color picker selects only the matching preset for lowercase colors', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'calino-storage',
+        JSON.stringify({
+          state: {
+            calendars: [
+              {
+                id: 'default',
+                name: 'Offline calendar',
+                color: '#ea4335',
+                isVisible: true,
+                isDefault: true,
+                showTasksInViews: true,
+              },
+            ],
+          },
+          version: 1,
+        })
+      )
+    })
+
+    await page.goto('/month')
+    await page.locator('[data-component="calendar-section-toggle"]').click()
+    await page.getByRole('button', { name: 'Change Offline calendar color' }).click()
+
+    const preset = page.getByRole('button', { name: 'Use #EA4335 for Offline calendar' })
+    const customColor = page.getByLabel('Custom color for Offline calendar').locator('..')
+    await expect
+      .poll(() => preset.evaluate((element) => getComputedStyle(element, '::after').content))
+      .toBe('"✓"')
+    await expect
+      .poll(() => customColor.evaluate((element) => getComputedStyle(element, '::after').content))
+      .toBe('none')
+  })
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,15 +31,6 @@ export const CALENDAR_COLORS = [
 
 export const EVENT_COLORS = [...CALENDAR_COLORS, '#9334E6'] as const
 
-/**
- * Return the next color in the CALENDAR_COLORS rotation after `currentColor`.
- * If `currentColor` is not in the list, returns the first color.
- */
-export function getNextColor(currentColor: string): string {
-  const idx = CALENDAR_COLORS.indexOf(currentColor as typeof CALENDAR_COLORS[number])
-  return CALENDAR_COLORS[(idx + 1) % CALENDAR_COLORS.length]
-}
-
 export const MOBILE_BREAKPOINT = 768
 export const COMPACT_MOBILE_BREAKPOINT = 500
 export const TABLET_BREAKPOINT = 1220

--- a/src/features/calendar/__tests__/Sidebar.test.tsx
+++ b/src/features/calendar/__tests__/Sidebar.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/features/caldav/hooks/useCalDAV', () => ({
 }))
 
 import { Sidebar } from '../components/Sidebar'
+import styles from '../components/Sidebar.module.css'
 import { useCalendarStore } from '@/store/calendarStore'
 
 function renderWithRouter(component: React.ReactElement) {
@@ -112,6 +113,20 @@ describe('Sidebar', () => {
     await user.click(screen.getByRole('button', { name: 'Use #EA4335 for Default Calendar' }))
 
     expect(mockUpdateCalDAVCalendar).toHaveBeenCalledWith('default', { color: '#EA4335' })
+  })
+
+  it('does not select the custom color swatch when a lowercase color matches a preset', async () => {
+    const user = userEvent.setup()
+    useCalendarStore.getState().updateCalendar('default', { color: '#ea4335' })
+    renderWithRouter(<Sidebar />)
+
+    await user.click(screen.getByRole('button', { name: /^calendars/i }))
+    await user.click(screen.getByRole('button', { name: 'Change Default Calendar color' }))
+
+    expect(screen.getByRole('button', { name: 'Use #EA4335 for Default Calendar' }))
+      .toHaveClass(styles.colorPresetSelected)
+    expect(screen.getByLabelText('Custom color for Default Calendar').parentElement)
+      .not.toHaveClass(styles.customColorPickerSelected)
   })
 
   it('renders weekday headers in mini calendar', () => {

--- a/src/features/calendar/__tests__/Sidebar.test.tsx
+++ b/src/features/calendar/__tests__/Sidebar.test.tsx
@@ -1,7 +1,21 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
+const { mockUpdateCalDAVCalendar } = vi.hoisted(() => ({
+  mockUpdateCalDAVCalendar: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/features/caldav/hooks/useCalDAV', () => ({
+  useCalDAV: () => ({
+    accounts: [],
+    syncAccount: vi.fn(),
+    syncState: { status: 'idle' },
+    updateCalendar: mockUpdateCalDAVCalendar,
+    deleteCalendarFromServer: vi.fn(),
+  }),
+}))
+
 import { Sidebar } from '../components/Sidebar'
 import { useCalendarStore } from '@/store/calendarStore'
 
@@ -11,6 +25,7 @@ function renderWithRouter(component: React.ReactElement) {
 
 describe('Sidebar', () => {
   beforeEach(() => {
+    mockUpdateCalDAVCalendar.mockClear()
     const store = useCalendarStore.getState()
     store.events.forEach((e) => store.deleteEvent(e.id))
     store.calendars.forEach((c) => store.deleteCalendar(c.id))
@@ -85,6 +100,18 @@ describe('Sidebar', () => {
     await user.click(screen.getByRole('button', { name: /^calendars/i }))
     const colorDots = document.querySelectorAll('button[class*="colorDot"]')
     expect(colorDots.length).toBeGreaterThan(0)
+  })
+
+  it('updates a CalDAV calendar when its color changes', async () => {
+    const user = userEvent.setup()
+    useCalendarStore.getState().updateCalendar('default', { accountId: 'account-1' })
+    renderWithRouter(<Sidebar />)
+
+    await user.click(screen.getByRole('button', { name: /^calendars/i }))
+    await user.click(screen.getByRole('button', { name: 'Change Default Calendar color' }))
+    await user.click(screen.getByRole('button', { name: 'Use #EA4335 for Default Calendar' }))
+
+    expect(mockUpdateCalDAVCalendar).toHaveBeenCalledWith('default', { color: '#EA4335' })
   })
 
   it('renders weekday headers in mini calendar', () => {

--- a/src/features/calendar/components/Sidebar.module.css
+++ b/src/features/calendar/components/Sidebar.module.css
@@ -564,8 +564,107 @@
   transition: transform var(--dur-fast);
 }
 
+.colorPicker {
+  position: relative;
+  display: flex;
+  flex: 0 0 auto;
+}
+
 .colorDot:hover {
   transform: scale(1.3);
+}
+
+.colorDot:focus-visible,
+.colorPreset:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.colorPickerMenu {
+  position: absolute;
+  z-index: 110;
+  top: calc(100% + 6px);
+  left: -8px;
+  padding: 8px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 12px rgba(var(--ink-raw), 0.1);
+}
+
+.colorPresets {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.colorPreset {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: 2px solid transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: transform var(--dur-fast), box-shadow var(--dur-fast);
+}
+
+.colorPreset:hover {
+  transform: scale(1.12);
+}
+
+.colorPresetSelected {
+  border-color: transparent;
+}
+
+.customColorPicker {
+  position: relative;
+  display: block;
+  flex: 0 0 20px;
+  width: 20px;
+  height: 20px;
+  overflow: hidden;
+  border-radius: 50%;
+  background: conic-gradient(#e85b5b, #e6c24f, #63b46d, #4fa8c9, #7468c7, #d261a4, #e85b5b);
+  cursor: pointer;
+  transition: transform var(--dur-fast);
+}
+
+.customColorPicker:hover {
+  transform: scale(1.12);
+}
+
+.colorPresetSelected::after,
+.customColorPickerSelected::after {
+  content: '✓';
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  text-shadow: 0 1px 2px rgba(var(--ink-raw), 0.65);
+  pointer-events: none;
+}
+
+.customColorPicker:focus-within {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
+}
+
+.customColorPicker input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+  cursor: pointer;
 }
 
 .calName {

--- a/src/features/calendar/components/Sidebar.tsx
+++ b/src/features/calendar/components/Sidebar.tsx
@@ -682,7 +682,15 @@ export function Sidebar({ isOpen = false, onClose, isCollapsed: controlledCollap
                                 aria-label={`Use ${color} for ${calendar.name}`}
                               />
                             ))}
-                            <span className={`${styles.customColorPicker} ${!CALENDAR_COLOR_PRESETS.includes(calendar.color) ? styles.customColorPickerSelected : ''}`}>
+                            <span
+                              className={`${styles.customColorPicker} ${
+                                !CALENDAR_COLOR_PRESETS.some(
+                                  (preset) => preset.toLowerCase() === calendar.color.toLowerCase()
+                                )
+                                  ? styles.customColorPickerSelected
+                                  : ''
+                              }`}
+                            >
                               <input
                                 type="color"
                                 value={calendar.color}

--- a/src/features/calendar/components/Sidebar.tsx
+++ b/src/features/calendar/components/Sidebar.tsx
@@ -19,7 +19,7 @@ import {
   subMonths,
   parseISO,
 } from 'date-fns'
-import { config, TOAST_DURATION_MS, getNextColor } from '@/config'
+import { CALENDAR_COLORS, config, TOAST_DURATION_MS } from '@/config'
 import { useCalendarStore } from '@/store/calendarStore'
 import { useSettingsStore } from '@/store/settingsStore'
 import { useCalDAVSyncStore } from '@/store/caldavSyncStore'
@@ -35,6 +35,7 @@ import { MiniTasksSection } from './MiniTasksSection'
 import styles from './Sidebar.module.css'
 
 let hasAutoSyncedCalendars = false
+const CALENDAR_COLOR_PRESETS = [...CALENDAR_COLORS.slice(0, 4), '#7B1FA2']
 
 interface SidebarProps {
   isOpen?: boolean
@@ -64,6 +65,7 @@ export function Sidebar({ isOpen = false, onClose, isCollapsed: controlledCollap
   const syncAllRequestRef = useRef<Promise<void> | null>(null)
   const [isCalendarsExpanded, setIsCalendarsExpanded] = useState(false)
   const [isCategoriesExpanded, setIsCategoriesExpanded] = useState(false)
+  const [colorPickerCalendarId, setColorPickerCalendarId] = useState<string | null>(null)
   const [syncingCalendarId, setSyncingCalendarId] = useState<string | null>(null)
   const [isSyncingAll, setIsSyncingAll] = useState(false)
   const [syncStatus, setSyncStatus] = useState<Record<string, 'success' | 'error'>>({})
@@ -81,6 +83,7 @@ export function Sidebar({ isOpen = false, onClose, isCollapsed: controlledCollap
   const [deleteCalendarName, setDeleteCalendarName] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const colorPickerRef = useRef<HTMLDivElement>(null)
   const currentDate = useCalendarStore((state) => state.currentDate)
   const setCurrentDate = useCalendarStore((state) => state.setCurrentDate)
   const calendars = useCalendarStore((state) => state.calendars)
@@ -311,10 +314,30 @@ export function Sidebar({ isOpen = false, onClose, isCollapsed: controlledCollap
     }
   }
 
-  const handleColorClick = (calendarId: string, currentColor: string): void => {
-    const nextColor = getNextColor(currentColor)
-    updateCalendar(calendarId, { color: nextColor })
+  const handleColorChange = (calendarId: string, color: string): void => {
+    updateCalendar(calendarId, { color })
+    setColorPickerCalendarId(null)
   }
+
+  useEffect(() => {
+    if (!colorPickerCalendarId) return
+
+    const handlePointerDown = (event: PointerEvent): void => {
+      if (!colorPickerRef.current?.contains(event.target as Node)) {
+        setColorPickerCalendarId(null)
+      }
+    }
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') setColorPickerCalendarId(null)
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [colorPickerCalendarId])
 
   const [isResizing, setIsResizing] = useState(false)
   const COLLAPSE_THRESHOLD = 255
@@ -614,13 +637,53 @@ export function Sidebar({ isOpen = false, onClose, isCollapsed: controlledCollap
                       onChange={() => toggleCalendarVisibility(calendar.id)}
                       className={styles.checkbox}
                     />
-                    <button
-                      className={styles.colorDot}
-                      style={{ backgroundColor: calendar.color }}
-                      onClick={() => handleColorClick(calendar.id, calendar.color)}
-                      title="Click to change color"
-                      aria-label={`Change ${calendar.name} color`}
-                    />
+                    <div className={styles.colorPicker} ref={colorPickerCalendarId === calendar.id ? colorPickerRef : undefined}>
+                      <button
+                        type="button"
+                        className={styles.colorDot}
+                        style={{ backgroundColor: calendar.color }}
+                        onClick={(event) => {
+                          event.preventDefault()
+                          setColorPickerCalendarId((current) => current === calendar.id ? null : calendar.id)
+                        }}
+                        aria-label={`Change ${calendar.name} color`}
+                        aria-expanded={colorPickerCalendarId === calendar.id}
+                        aria-controls={`calendar-color-picker-${calendar.id}`}
+                      />
+                      {colorPickerCalendarId === calendar.id && (
+                        <div
+                          id={`calendar-color-picker-${calendar.id}`}
+                          className={styles.colorPickerMenu}
+                          role="group"
+                          aria-label={`Color picker for ${calendar.name}`}
+                          data-component="calendar-color-picker"
+                        >
+                          <div className={styles.colorPresets}>
+                            {CALENDAR_COLOR_PRESETS.map((color) => (
+                              <button
+                                key={color}
+                                type="button"
+                                className={`${styles.colorPreset} ${calendar.color.toLowerCase() === color.toLowerCase() ? styles.colorPresetSelected : ''}`}
+                                style={{ backgroundColor: color }}
+                                onClick={(event) => {
+                                  event.preventDefault()
+                                  handleColorChange(calendar.id, color)
+                                }}
+                                aria-label={`Use ${color} for ${calendar.name}`}
+                              />
+                            ))}
+                            <span className={`${styles.customColorPicker} ${!CALENDAR_COLOR_PRESETS.includes(calendar.color) ? styles.customColorPickerSelected : ''}`}>
+                              <input
+                                type="color"
+                                value={calendar.color}
+                                onChange={(event) => handleColorChange(calendar.id, event.target.value)}
+                                aria-label={`Custom color for ${calendar.name}`}
+                              />
+                            </span>
+                          </div>
+                        </div>
+                      )}
+                    </div>
                     {editingId === calendar.id ? (
                       <input
                         ref={inputRef}

--- a/src/features/calendar/components/Sidebar.tsx
+++ b/src/features/calendar/components/Sidebar.tsx
@@ -314,9 +314,19 @@ export function Sidebar({ isOpen = false, onClose, isCollapsed: controlledCollap
     }
   }
 
-  const handleColorChange = (calendarId: string, color: string): void => {
+  const handleColorChange = async (calendarId: string, color: string): Promise<void> => {
+    const calendar = calendars.find((item) => item.id === calendarId)
     updateCalendar(calendarId, { color })
     setColorPickerCalendarId(null)
+
+    if (calendar?.accountId) {
+      try {
+        await updateCalDAVCalendar(calendarId, { color })
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : 'unknown error'
+        showToast(`Color changed locally, but the server update failed: ${detail}`)
+      }
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Replace the sidebar calendar color rotation with a color picker.
- Provide five color presets and a custom color selector.
- Persist color changes to CalDAV calendars, matching the existing rename behavior.
- Keep local changes when a server update fails and show an error notification.

## Tests

- Added sidebar coverage for CalDAV color updates.
- Verified the color picker flow with Playwright.