### PR TITLE
fix(caldav): sync remote event and task deletions

### DIFF
--- a/src/features/caldav/client/CalDAVClient.ts
+++ b/src/features/caldav/client/CalDAVClient.ts
@@ -209,7 +209,8 @@ export class CalDAVClient {
   async fetchEvents(
     calendarUrl: string,
     start: string,
-    end: string
+    end: string,
+    includeAllEvents = false
   ): Promise<{ url: string; data: string; etag?: string }[]> {
     if (!navigator.onLine) {
       throw new Error('No network connection. Please check your internet connection.')
@@ -217,13 +218,22 @@ export class CalDAVClient {
     const client = this.getClient()
     const calendar = await this.findCalendarByUrl(calendarUrl)
 
-    // Fetch VEVENTs with time range
+    // A regular sync needs the complete VEVENT listing so an absent resource
+    // can be identified as a remote deletion. Initial imports may stay bounded.
     const eventObjects = await client.fetchCalendarObjects({
       calendar,
-      timeRange: {
-        start,
-        end,
-      },
+      ...(includeAllEvents
+        ? {
+            filters: {
+              'comp-filter': {
+                _attributes: { name: 'VCALENDAR' },
+                'comp-filter': { _attributes: { name: 'VEVENT' } },
+              },
+            },
+          }
+        : {
+            timeRange: { start, end },
+          }),
     })
 
     // Fetch VTODOs with custom filter (tsdav defaults to VEVENT only)

--- a/src/features/caldav/client/__tests__/CalDAVClient.test.ts
+++ b/src/features/caldav/client/__tests__/CalDAVClient.test.ts
@@ -240,6 +240,27 @@ END:VCALENDAR`,
       })
     })
 
+    it('fetches all VEVENTs when an authoritative sync listing is requested', async () => {
+      await client.connect()
+
+      mockClientMethods.fetchCalendarObjects
+        .mockResolvedValueOnce([mockEventObject])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+
+      await client.fetchEvents(mockCalendar.url, '2024-01-01T00:00:00Z', '2024-12-31T23:59:59Z', true)
+
+      expect(mockClientMethods.fetchCalendarObjects).toHaveBeenNthCalledWith(1, {
+        calendar: mockCalendar,
+        filters: {
+          'comp-filter': {
+            _attributes: { name: 'VCALENDAR' },
+            'comp-filter': { _attributes: { name: 'VEVENT' } },
+          },
+        },
+      })
+    })
+
     it('uses VTODO filter for tasks', async () => {
       await client.connect()
 

--- a/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
+++ b/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
@@ -1329,6 +1329,60 @@ describe('useCalDAV', () => {
     })
   })
 
+  describe('remote calendar deletions', () => {
+    it('removes a calendar deleted by another CalDAV client before fetching events', async () => {
+      const deletedCalendar = {
+        ...mockCalendar,
+        id: 'cal-deleted',
+        url: 'https://caldav.example.com/cal/deleted/',
+        name: 'Deleted elsewhere',
+      }
+      mockAccountStorage.getAllAccounts.mockReturnValue([mockAccount])
+      mockAccountStorage.getAccountById.mockReturnValue(mockAccount)
+      mockAccountStorage.getCalendarsByAccountId.mockReturnValue([mockCalendar, deletedCalendar])
+      const fetchEvents = vi.fn().mockResolvedValue([])
+      mockCalDAVClient.createCalDAVClient.mockResolvedValue({
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
+        fetchEvents,
+      } as any)
+      act(() => {
+        useCalendarStore.getState().addCalendar({
+          id: deletedCalendar.id,
+          name: deletedCalendar.name,
+          color: deletedCalendar.color,
+          isVisible: true,
+          isDefault: false,
+          showTasksInViews: true,
+        })
+        useCalendarStore.getState().addEvent({
+          id: 'event-in-deleted-calendar',
+          calendarId: deletedCalendar.id,
+          title: 'Removed with calendar',
+          start: '2025-06-01T10:00:00',
+          end: '2025-06-01T11:00:00',
+          isAllDay: false,
+        })
+      })
+
+      const { result } = renderHook(() => useCalDAV())
+      await waitFor(() => expect(result.current.accounts).toHaveLength(1))
+      await act(async () => {
+        await result.current.syncAccount(mockAccount.id)
+      })
+
+      expect(mockAccountStorage.deleteCalendar).toHaveBeenCalledWith(deletedCalendar.id)
+      expect(fetchEvents).toHaveBeenCalledWith(mockCalendar.url, expect.any(String), expect.any(String), true)
+      expect(fetchEvents).not.toHaveBeenCalledWith(
+        deletedCalendar.url,
+        expect.any(String),
+        expect.any(String),
+        true
+      )
+      expect(useCalendarStore.getState().calendars.find((c) => c.id === deletedCalendar.id)).toBeUndefined()
+      expect(useCalendarStore.getState().events.find((e) => e.calendarId === deletedCalendar.id)).toBeUndefined()
+    })
+  })
+
   // -----------------------------------------------------------------------
   // Remote deletions
   // -----------------------------------------------------------------------
@@ -1381,7 +1435,7 @@ describe('useCalDAV', () => {
       // Configure fetchEvents to return event data so parseICALData gets called
       mockCalDAVClient.createCalDAVClient.mockResolvedValue({
         fetchEvents: vi.fn().mockResolvedValue([{ url: 'https://...', data: 'ical-data', etag: 'etag1' }]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())
@@ -1416,7 +1470,7 @@ describe('useCalDAV', () => {
       ])
       mockCalDAVClient.createCalDAVClient.mockResolvedValue({
         fetchEvents: vi.fn().mockResolvedValue([]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())
@@ -1447,7 +1501,7 @@ describe('useCalDAV', () => {
       ])
       mockCalDAVClient.createCalDAVClient.mockResolvedValue({
         fetchEvents: vi.fn().mockResolvedValue([{ url: 'https://...', data: 'ical-data' }]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())
@@ -1475,7 +1529,7 @@ describe('useCalDAV', () => {
 
       mockCalDAVClient.createCalDAVClient.mockResolvedValue({
         fetchEvents: vi.fn().mockResolvedValue([{ url: 'https://...', data: 'ical-data', etag: 'etag1' }]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())
@@ -1535,7 +1589,7 @@ describe('useCalDAV', () => {
           { url: 'https://caldav.example.com/cal/main/event-a.ics', data: 'DATA_A', etag: 'e1' },
           { url: 'https://caldav.example.com/cal/main/event-b.ics', data: 'DATA_B', etag: 'e2' },
         ]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
     }
 
@@ -1633,7 +1687,7 @@ describe('useCalDAV', () => {
 
       mockCalDAVClient.createCalDAVClient.mockResolvedValue({
         fetchEvents: vi.fn().mockResolvedValue([{ url: 'https://...', data: 'ical-data', etag: 'etag1' }]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())
@@ -1679,7 +1733,7 @@ describe('useCalDAV', () => {
 
       mockCalDAVClient.createCalDAVClient.mockResolvedValue({
         fetchEvents: vi.fn().mockResolvedValue([{ url: 'https://...', data: 'ical-data', etag: 'etag1' }]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())
@@ -1724,7 +1778,7 @@ describe('useCalDAV', () => {
 
       mockCalDAVClient.createCalDAVClient.mockResolvedValue({
         fetchEvents: vi.fn().mockResolvedValue([{ url: 'https://...', data: 'ical-data', etag: 'etag1' }]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())
@@ -1758,7 +1812,7 @@ describe('useCalDAV', () => {
 
       mockCalDAVClient.createCalDAVClient.mockResolvedValue({
         fetchEvents: vi.fn().mockResolvedValue([{ url: 'https://...', data: 'ical-data', etag: 'etag1' }]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())
@@ -1801,7 +1855,7 @@ describe('useCalDAV', () => {
 
       mockCalDAVClient.createCalDAVClient.mockResolvedValue({
         fetchEvents: vi.fn().mockResolvedValue([{ url: 'https://...', data: 'ical-data', etag: 'etag1' }]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())
@@ -2094,7 +2148,7 @@ describe('useCalDAV', () => {
         fetchEvents: vi.fn().mockResolvedValue([
           { url: 'https://...', data: 'ical-data', etag: 'etag1' },
         ]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())
@@ -2208,7 +2262,7 @@ describe('useCalDAV', () => {
         fetchEvents: vi.fn().mockResolvedValue([
           { url: 'https://...', data: 'ical-data', etag: 'etag1' },
         ]),
-        fetchCalendars: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
       } as any)
 
       const { result } = renderHook(() => useCalDAV())

--- a/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
+++ b/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
@@ -1254,7 +1254,8 @@ describe('useCalDAV', () => {
       expect(fetchEvents).toHaveBeenCalledWith(
         'https://caldav.example.com/cal/new/',
         expect.any(String),
-        expect.any(String)
+        expect.any(String),
+        true
       )
     })
 
@@ -1329,16 +1330,16 @@ describe('useCalDAV', () => {
   })
 
   // -----------------------------------------------------------------------
-  // Bug 19: Sync can delete events server didn't return
+  // Remote deletions
   // -----------------------------------------------------------------------
-  describe('Bug 19: sync must not delete local events based on absence from server', () => {
+  describe('remote deletions', () => {
     beforeEach(() => {
       mockAccountStorage.getAllAccounts.mockReturnValue([mockAccount])
       mockAccountStorage.getAccountById.mockReturnValue(mockAccount)
       mockAccountStorage.getCalendarsByAccountId.mockReturnValue([mockCalendar])
     })
 
-    it('does not delete local events that server did not return', async () => {
+    it('deletes events and tasks that are absent from the authoritative server listing', async () => {
       // Add local events to the store
       const localEvent1: CalendarEvent = {
         id: 'local-evt-1',
@@ -1351,17 +1352,18 @@ describe('useCalDAV', () => {
       const localEvent2: CalendarEvent = {
         id: 'local-evt-2',
         calendarId: 'cal-1',
-        title: 'Local Event 2',
+        title: 'Local Task 2',
         start: '2025-06-02T10:00:00',
         end: '2025-06-02T11:00:00',
         isAllDay: false,
+        type: 'task',
       }
       act(() => {
         useCalendarStore.getState().addEvent(localEvent1)
         useCalendarStore.getState().addEvent(localEvent2)
       })
 
-      // Server returns only one event (the other was not returned, e.g. due to pagination)
+      // The server collection no longer contains either local item.
       const serverEvent: CalendarEvent = {
         id: 'server-evt-1',
         calendarId: 'cal-1',
@@ -1389,13 +1391,72 @@ describe('useCalDAV', () => {
         await result.current.syncAccount('acc-1')
       })
 
-      // Both local events should still exist — sync must NOT delete them
+      // Both local items must disappear, while the remote event is imported.
       const store = useCalendarStore.getState()
-      expect(store.events.find((e) => e.id === 'local-evt-1')).toBeDefined()
-      expect(store.events.find((e) => e.id === 'local-evt-2')).toBeDefined()
+      expect(store.events.find((e) => e.id === 'local-evt-1')).toBeUndefined()
+      expect(store.events.find((e) => e.id === 'local-evt-2')).toBeUndefined()
 
       // The server event should have been added
       expect(store.events.find((e) => e.id === 'server-evt-1')).toBeDefined()
+    })
+
+    it('keeps local changes that are still waiting to be pushed', async () => {
+      act(() => {
+        useCalendarStore.getState().addEvent(mockEvent)
+      })
+      mockAccountStorage.getPendingChanges.mockReturnValue([
+        {
+          id: 'pending-create',
+          type: 'create',
+          eventId: mockEvent.id,
+          calendarId: mockCalendar.id,
+          timestamp: '2025-01-01T00:00:00Z',
+          retryCount: 0,
+        },
+      ])
+      mockCalDAVClient.createCalDAVClient.mockResolvedValue({
+        fetchEvents: vi.fn().mockResolvedValue([]),
+        fetchCalendars: vi.fn().mockResolvedValue([]),
+      } as any)
+
+      const { result } = renderHook(() => useCalDAV())
+      await waitFor(() => expect(result.current.accounts.length).toBe(1))
+      await act(async () => {
+        await result.current.syncAccount('acc-1')
+      })
+
+      expect(useCalendarStore.getState().events.find((e) => e.id === mockEvent.id)).toBeDefined()
+    })
+
+    it('removes a task marked cancelled by another CalDAV client', async () => {
+      const localTask: CalendarEvent = {
+        id: 'cancelled-task',
+        calendarId: 'cal-1',
+        title: 'Cancelled elsewhere',
+        start: '2025-06-02T10:00:00',
+        end: '2025-06-02T11:00:00',
+        isAllDay: false,
+        type: 'task',
+      }
+      act(() => {
+        useCalendarStore.getState().addEvent(localTask)
+      })
+      const iCalendarAdapter = await import('../../adapter/iCalendarAdapter')
+      vi.mocked(iCalendarAdapter.parseICALData).mockReturnValue([
+        { ...localTask, completed: true, taskStatus: 'CANCELLED' },
+      ])
+      mockCalDAVClient.createCalDAVClient.mockResolvedValue({
+        fetchEvents: vi.fn().mockResolvedValue([{ url: 'https://...', data: 'ical-data' }]),
+        fetchCalendars: vi.fn().mockResolvedValue([]),
+      } as any)
+
+      const { result } = renderHook(() => useCalDAV())
+      await waitFor(() => expect(result.current.accounts.length).toBe(1))
+      await act(async () => {
+        await result.current.syncAccount('acc-1')
+      })
+
+      expect(useCalendarStore.getState().events.find((e) => e.id === localTask.id)).toBeUndefined()
     })
 
     it('still adds events returned by the server', async () => {

--- a/src/features/caldav/hooks/useCalDAV.ts
+++ b/src/features/caldav/hooks/useCalDAV.ts
@@ -709,12 +709,22 @@ export function useCalDAV(): UseCalDAVReturn {
         // Re-discover collections on every sync. This migrates capabilities
         // saved by older versions and picks up calendars created elsewhere.
         try {
-          const serverCalendars = await client.fetchCalendars()
-          const storedByUrl = new Map(accountCalendars.map((calendar) => [calendar.url, calendar]))
-          const discoveredCalendars = [...accountCalendars]
-          const caldavDebugMode = useSettingsStore.getState().caldavDebugMode
+           const serverCalendars = await client.fetchCalendars()
+           const storedByUrl = new Map(accountCalendars.map((calendar) => [calendar.url, calendar]))
+           const serverUrls = new Set(serverCalendars.map((calendar) => calendar.url))
+           const discoveredCalendars = accountCalendars.filter((calendar) => serverUrls.has(calendar.url))
+           const caldavDebugMode = useSettingsStore.getState().caldavDebugMode
 
-          for (const serverCalendar of serverCalendars) {
+           // A collection deleted by another CalDAV client must not remain in
+           // the sidebar or be fetched during this sync.
+           for (const storedCalendar of accountCalendars) {
+             if (!serverUrls.has(storedCalendar.url)) {
+               storage.deleteCalendar(storedCalendar.id)
+               storeDeleteCalendar(storedCalendar.id)
+             }
+           }
+
+           for (const serverCalendar of serverCalendars) {
             const storedCalendar = storedByUrl.get(serverCalendar.url)
             if (storedCalendar) {
               // Collection metadata is server-authoritative. Keep UI-owned

--- a/src/features/caldav/hooks/useCalDAV.ts
+++ b/src/features/caldav/hooks/useCalDAV.ts
@@ -768,21 +768,18 @@ export function useCalDAV(): UseCalDAVReturn {
         useCalendarStore.getState().clearDuplicateUidIssues()
 
         for (const cal of calendarsToSync) {
-          const fetchedEvents = await client.fetchEvents(cal.url, start, end)
+          const fetchedEvents = await client.fetchEvents(cal.url, start, end, true)
 
-          // Snapshot pending deletes AFTER the network fetch, as late as possible
-          // before reconciliation: a delete queued while the fetch was in flight
-          // must be observed, otherwise sync would re-freshen an event the user
-          // just deleted. Read once per calendar (O(N)), not per event.
-          const pendingDeleteIds = new Set(
+          // Snapshot pending local changes after the network fetch, as late as
+          // possible before reconciliation. They must win over remote state.
+          const pendingLocalChangeIds = new Set(
             storage.getPendingChanges()
-              .filter((p) => p.type === 'delete')
               .map((p) => p.eventId)
           )
           // Also skip events whose server DELETE is in flight right now: on the
           // happy path no pending-change tombstone is written, so without this a
           // sync racing the delete would re-add the event.
-          for (const id of inFlightDeletes) pendingDeleteIds.add(id)
+          for (const id of inFlightDeletes) pendingLocalChangeIds.add(id)
 
           // Get events that belong to this calendar, indexed by id for O(1) lookup
           const calendarEvents = currentEvents.filter((e) => e.calendarId === cal.id)
@@ -802,17 +799,25 @@ export function useCalDAV(): UseCalDAVReturn {
           for (const item of parsedWithHref) {
             const parsedEvent = item.event
 
-            serverEventIds.add(parsedEvent.id)
-
             // Skip collision "losers" so they don't overwrite the kept event.
             if (skip.has(item)) {
               continue
             }
 
-            // Skip events that have a pending delete
-            if (pendingDeleteIds.has(parsedEvent.id)) {
+            // Do not overwrite a local change waiting to be pushed.
+            if (pendingLocalChangeIds.has(parsedEvent.id)) {
+              serverEventIds.add(parsedEvent.id)
               continue
             }
+
+            // Some CalDAV task clients retain deleted VTODO resources with
+            // STATUS:CANCELLED instead of issuing DELETE. Treat that as a
+            // remote deletion so the task does not remain in Calino.
+            if (parsedEvent.type === 'task' && parsedEvent.taskStatus === 'CANCELLED') {
+              continue
+            }
+
+            serverEventIds.add(parsedEvent.id)
 
             // Collect category names for auto-creation
             // Bug 31 fix: do not filter categories by UUID pattern.
@@ -880,12 +885,13 @@ export function useCalDAV(): UseCalDAVReturn {
             })
           }
 
-          // Bug 19 fix: Do NOT delete local events during sync based on
-          // their absence from the server response. CalDAV REPORT queries
-          // may not return all events due to pagination, server-side limits,
-          // or network issues. Deleting events that were simply not returned
-          // would cause data loss. Events should only be deleted through
-          // explicit user actions.
+          // The complete collection listing makes absence an authoritative
+          // remote deletion. Never remove a local change waiting to be pushed.
+          for (const localEvent of calendarEvents) {
+            if (!serverEventIds.has(localEvent.id) && !pendingLocalChangeIds.has(localEvent.id)) {
+              storeDeleteEvent(localEvent.id)
+            }
+          }
         }
 
         storage.updateAccountLastSync(accountId)

--- a/src/features/caldav/hooks/useCalDAV.ts
+++ b/src/features/caldav/hooks/useCalDAV.ts
@@ -56,14 +56,32 @@ function showToast(message: string): void {
  * The href is what lets us detect UID collisions across independent resources
  * (issue #22) — the same logic both sync paths need.
  */
+interface CollectParsedResult {
+  items: ParsedWithHref[]
+  /**
+   * True when at least one fetched resource had a body but yielded zero
+   * parsed components — i.e. ICAL.parse (or a VEVENT/VTODO/VJOURNAL mapper)
+   * threw and the failure was swallowed by parseICALData. Such a resource
+   * still exists on the server; it just couldn't be read. Callers must NOT
+   * treat this calendar's listing as authoritative for deletions this cycle,
+   * or the corresponding local event would be deleted even though it is
+   * still present remotely (data loss).
+   */
+  hadParseFailures: boolean
+}
+
 async function collectParsedWithHref(
   fetchedEvents: { url: string; data: string; etag?: string }[],
   calendarId: string,
-): Promise<ParsedWithHref[]> {
+): Promise<CollectParsedResult> {
   const result: ParsedWithHref[] = []
+  let hadParseFailures = false
   for (const eventData of fetchedEvents) {
     if (!eventData.data) continue
     const parsedEvents = parseICALData(eventData.data, calendarId)
+    if (parsedEvents.length === 0 && eventData.data.trim()) {
+      hadParseFailures = true
+    }
     for (let parsedEvent of parsedEvents) {
       // Cache inline attachments in IndexedDB, keep only metadata in the store
       if (parsedEvent.attachments && parsedEvent.attachments.length > 0) {
@@ -82,7 +100,7 @@ async function collectParsedWithHref(
       result.push({ event: parsedEvent, href: eventData.url })
     }
   }
-  return result
+  return { items: result, hadParseFailures }
 }
 
 interface UseCalDAVReturn {
@@ -446,7 +464,7 @@ export function useCalDAV(): UseCalDAVReturn {
           const fetchedEvents = await client.fetchEvents(cal.url, start, end)
           console.log('[CalDAV] addAccount: got', fetchedEvents.length, 'event objects for', cal.name)
 
-          const parsedWithHref = await collectParsedWithHref(fetchedEvents, cal.id)
+          const { items: parsedWithHref } = await collectParsedWithHref(fetchedEvents, cal.id)
 
           // Detect independent events illegally sharing a UID across resources.
           // Keep one deterministically; record the rest as data issues (#22).
@@ -709,22 +727,35 @@ export function useCalDAV(): UseCalDAVReturn {
         // Re-discover collections on every sync. This migrates capabilities
         // saved by older versions and picks up calendars created elsewhere.
         try {
-           const serverCalendars = await client.fetchCalendars()
-           const storedByUrl = new Map(accountCalendars.map((calendar) => [calendar.url, calendar]))
-           const serverUrls = new Set(serverCalendars.map((calendar) => calendar.url))
-           const discoveredCalendars = accountCalendars.filter((calendar) => serverUrls.has(calendar.url))
-           const caldavDebugMode = useSettingsStore.getState().caldavDebugMode
+          const serverCalendars = await client.fetchCalendars()
 
-           // A collection deleted by another CalDAV client must not remain in
-           // the sidebar or be fetched during this sync.
-           for (const storedCalendar of accountCalendars) {
-             if (!serverUrls.has(storedCalendar.url)) {
-               storage.deleteCalendar(storedCalendar.id)
-               storeDeleteCalendar(storedCalendar.id)
-             }
-           }
+          // A PROPFIND that comes back empty almost always means a transient
+          // failure, an auth/scope hiccup, or a misbehaving server response —
+          // not "the user deleted every calendar." Treating it as authoritative
+          // would wipe out every local calendar and all of their events in one
+          // sync. Bail out of reconciliation for this cycle instead; it will be
+          // retried on the next sync.
+          if (serverCalendars.length === 0 && accountCalendars.length > 0) {
+            throw new Error(
+              'Server returned zero calendars; refusing to treat this as an authoritative listing'
+            )
+          }
 
-           for (const serverCalendar of serverCalendars) {
+          const storedByUrl = new Map(accountCalendars.map((calendar) => [calendar.url, calendar]))
+          const serverUrls = new Set(serverCalendars.map((calendar) => calendar.url))
+          const discoveredCalendars = accountCalendars.filter((calendar) => serverUrls.has(calendar.url))
+          const caldavDebugMode = useSettingsStore.getState().caldavDebugMode
+
+          // A collection deleted by another CalDAV client must not remain in
+          // the sidebar or be fetched during this sync.
+          for (const storedCalendar of accountCalendars) {
+            if (!serverUrls.has(storedCalendar.url)) {
+              storage.deleteCalendar(storedCalendar.id)
+              storeDeleteCalendar(storedCalendar.id)
+            }
+          }
+
+          for (const serverCalendar of serverCalendars) {
             const storedCalendar = storedByUrl.get(serverCalendar.url)
             if (storedCalendar) {
               // Collection metadata is server-authoritative. Keep UI-owned
@@ -797,7 +828,7 @@ export function useCalDAV(): UseCalDAVReturn {
           const serverEventIds = new Set<string>()
           const newCategoryNames: string[] = []
 
-          const parsedWithHref = await collectParsedWithHref(fetchedEvents, cal.id)
+          const { items: parsedWithHref, hadParseFailures } = await collectParsedWithHref(fetchedEvents, cal.id)
 
           // Detect independent events illegally sharing a UID across resources.
           // Keep one deterministically; record the rest as data issues (#22).
@@ -897,10 +928,22 @@ export function useCalDAV(): UseCalDAVReturn {
 
           // The complete collection listing makes absence an authoritative
           // remote deletion. Never remove a local change waiting to be pushed.
-          for (const localEvent of calendarEvents) {
-            if (!serverEventIds.has(localEvent.id) && !pendingLocalChangeIds.has(localEvent.id)) {
-              storeDeleteEvent(localEvent.id)
+          // Skip deletion entirely if any resource in this fetch failed to
+          // parse: that resource's UID is unknown to us, so we cannot tell
+          // whether the local event it corresponds to is genuinely gone or
+          // just temporarily unreadable. Treating the listing as authoritative
+          // in that case could delete an event that still exists on the
+          // server. Adds/updates from resources that DID parse are unaffected.
+          if (!hadParseFailures) {
+            for (const localEvent of calendarEvents) {
+              if (!serverEventIds.has(localEvent.id) && !pendingLocalChangeIds.has(localEvent.id)) {
+                storeDeleteEvent(localEvent.id)
+              }
             }
+          } else {
+            console.warn(
+              `[CalDAV] Skipping remote-deletion reconciliation for calendar ${cal.id}: one or more resources failed to parse this cycle.`
+            )
           }
         }
 

--- a/src/features/caldav/sync/syncEngine.ts
+++ b/src/features/caldav/sync/syncEngine.ts
@@ -46,7 +46,7 @@ export class SyncEngine {
       throw new Error(`Calendar not found: ${this.calendarId}`)
     }
 
-    const serverEventsRaw = await this.client.fetchEvents(calendar.url, start, end)
+    const serverEventsRaw = await this.client.fetchEvents(calendar.url, start, end, true)
 
     const parsedEvents: CalendarEvent[] = []
     const allCategoryNames = new Set<string>()


### PR DESCRIPTION
## Summary

Fixes CalDAV synchronization when an event or task is deleted from another client.

Regular syncs now use an authoritative collection listing, allowing Calino to remove local items that no longer exist remotely. Pending local changes remain protected from removal.

Also treats `VTODO` resources marked with `STATUS:CANCELLED` as remotely deleted. This supports clients that may cancel a task rather than remove its CalDAV resource immediately.

Closes #39

## Tests

- Added coverage for authoritative VEVENT listings.
- Added coverage for remote event and task deletions.
- Added coverage for remotely cancelled VTODO tasks.