### PR TITLE
feat(themes): add Catppuccin dark theme

### DIFF
--- a/e2e/native-controls-theme.spec.ts
+++ b/e2e/native-controls-theme.spec.ts
@@ -2,6 +2,80 @@ import { test, expect } from '@playwright/test'
 import { clearState, STORAGE_KEYS } from './fixtures/localstorage'
 
 test.describe('native controls follow the active theme', () => {
+  test('Catppuccin is selectable, persists, and styles dark controls', async ({ page }) => {
+    await clearState(page)
+    await page.goto('/settings')
+    await page.getByRole('button', { name: 'Appearance' }).click()
+
+    await page.locator('[data-component="theme-mode-option"][data-value="dark"]').click()
+    const mochaCard = page.locator(
+      '[data-component="theme-preview-card"][data-theme-id="Catppuccin"]'
+    )
+    await expect(mochaCard).toBeVisible()
+    await mochaCard.click()
+
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
+    await expect(page.locator('html')).toHaveAttribute('data-theme-id', 'catppuccin-mocha')
+    await expect(mochaCard).toHaveAttribute('data-active', 'true')
+    await expect(page.locator('html')).toHaveCSS('--color-bg-primary', '#1e1e2e')
+    await expect(page.locator('html')).toHaveCSS('--color-text-primary', '#cdd6f4')
+    await expect(page.locator('html')).toHaveCSS('--event-rail-mix', '100%')
+    await expect(page.locator('html')).toHaveCSS('--event-marker-mix', '100%')
+    await page.getByRole('button', { name: 'Use Mauve accent' }).click()
+    await expect(page.locator('html')).toHaveCSS('--color-accent', '#cba6f7')
+    await page.goto('/month')
+    await expect(page.locator('[data-component="calendar-grid"] [data-today] button').first()).toHaveCSS(
+      'color',
+      'rgb(30, 30, 46)'
+    )
+
+    await page.goto('/tasks')
+    await page.locator('[data-component="add-task-button"]').click()
+    await page.getByPlaceholder('What needs doing?').fill('Mocha controls')
+    await page.getByPlaceholder('What needs doing?').press('Enter')
+    await expect(page.locator('#priority-select')).toBeVisible()
+
+    for (const selector of [
+      '#priority-select',
+      '[data-component="event-calendar-select"]',
+      '#due-date',
+    ]) {
+      await expect(page.locator(selector)).toHaveCSS('color-scheme', 'dark')
+    }
+
+    const calendarOption = page.locator('[data-component="event-calendar-select"] option').first()
+    await expect(calendarOption).toHaveCSS('background-color', 'rgb(49, 50, 68)')
+    await expect(calendarOption).toHaveCSS('color', 'rgb(205, 214, 244)')
+
+    await page.reload()
+    await expect(page.locator('html')).toHaveAttribute('data-theme-id', 'catppuccin-mocha')
+    await expect(page.locator('html')).toHaveCSS('--color-accent', '#cba6f7')
+    await expect(page.locator('html')).toHaveCSS('--color-bg-primary', '#1e1e2e')
+    await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(30, 30, 46)')
+  })
+
+  test('Catppuccin paints the document before React loads', async ({ page }) => {
+    await page.addInitScript(
+      ({ settingsKey }: { settingsKey: string }) => {
+        localStorage.setItem(
+          settingsKey,
+          JSON.stringify({
+            state: { themeMode: 'dark', darkTheme: 'catppuccin-mocha' },
+            version: 1,
+          })
+        )
+      },
+      { settingsKey: STORAGE_KEYS.settings }
+    )
+    await page.route('**/src/main.tsx', (route) => route.fulfill({ body: '' }))
+
+    await page.goto('/month')
+
+    await expect(page.locator('html')).toHaveCSS('background-color', 'rgb(30, 30, 46)')
+    await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(30, 30, 46)')
+    await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute('content', '#89b4fa')
+  })
+
   test('task selects and date inputs use the dark browser color scheme', async ({ page }) => {
     await clearState(page)
     await page.addInitScript(({ settingsKey }: { settingsKey: string }) => {

--- a/index.html
+++ b/index.html
@@ -86,9 +86,18 @@
       (function() {
         try {
           var stored = JSON.parse(localStorage.getItem('calino-settings') || '{}');
-          var mode = (stored.state && stored.state.themeMode) || 'auto';
+          var settings = stored.state || {};
+          var mode = settings.themeMode || 'auto';
           var isDark = mode === 'dark' || (mode === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-          document.body.style.background = isDark ? '#1a1816' : '#fafafa';
+          var isMocha = isDark && settings.darkTheme === 'catppuccin-mocha';
+          var mochaAccent = settings.mochaAccent || '#89b4fa';
+          var background = isMocha ? '#1e1e2e' : (isDark ? '#1a1816' : '#fafafa');
+          document.documentElement.style.background = background;
+          document.body.style.background = background;
+          if (isMocha) {
+            var themeColor = document.querySelector('meta[name="theme-color"]');
+            if (themeColor) themeColor.setAttribute('content', mochaAccent);
+          }
           document.body.style.transition = 'background 0.3s ease';
         } catch(e) {}
       })();

--- a/public/themes/catppuccin-mocha.css
+++ b/public/themes/catppuccin-mocha.css
@@ -1,0 +1,122 @@
+/* Theme: Catppuccin | dark */
+
+/* Official Catppuccin Mocha palette: https://catppuccin.com/palette */
+[data-theme='dark'] {
+  /* Backgrounds and surfaces */
+  --canvas: #1e1e2e;
+  --panel: #181825;
+  --side: #11111b;
+  --color-bg: var(--canvas);
+  --color-bg-primary: var(--canvas);
+  --color-bg-secondary: var(--panel);
+  --color-bg-secondary-rgb: 24, 24, 37;
+  --color-bg-tertiary: #313244;
+  --color-bg-hover: #313244;
+  --color-bg-input: #313244;
+  --color-surface: var(--panel);
+  --color-surface-raised: #313244;
+  --color-surface-glass: rgba(24, 24, 37, 0.88);
+  --color-surface-hover: #45475a;
+  --color-surface-elevated: #313244;
+
+  /* Semantic design tokens */
+  --background: var(--color-bg-primary);
+  --background-subtle: var(--color-bg-tertiary);
+  --surface: var(--color-surface);
+  --surface-hover: var(--color-surface-hover);
+  --surface-elevated: var(--color-surface-elevated);
+  --border: var(--color-border);
+  --text: var(--color-text-primary);
+  --text-muted: var(--color-text-muted);
+  --primary: var(--color-primary);
+  --primary-hover: var(--color-primary-hover);
+  --success: var(--color-success);
+  --warning: var(--color-warning);
+  --danger: var(--color-danger);
+  --info: var(--color-info);
+
+  /* Text */
+  --ink: #cdd6f4;
+  --ink-2: #bac2de;
+  --ink-3: #6c7086;
+  --color-text: var(--ink);
+  --color-text-primary: var(--ink);
+  --color-text-secondary: var(--ink-2);
+  --color-text-muted: var(--ink-3);
+  --color-text-tertiary: var(--ink-3);
+
+  /* Borders */
+  --line: #45475a;
+  --line-2: #313244;
+  --color-border: var(--line);
+  --color-border-light: var(--line-2);
+  --color-border-subtle: var(--line-2);
+  --color-border-visible: var(--line);
+  --color-border-glass: rgba(205, 214, 244, 0.12);
+
+  /* Primary and semantic states */
+  --accent: var(--accent-custom, #89b4fa);
+  --accent-contrast: #1e1e2e;
+  --accent-soft: color-mix(in srgb, var(--accent) 16%, transparent);
+  --color-accent: var(--accent);
+  --color-accent-hover: color-mix(in srgb, var(--accent) 72%, #cdd6f4);
+  --color-accent-light: var(--accent-soft);
+  --color-primary: var(--accent);
+  --color-primary-hover: color-mix(in srgb, var(--accent) 72%, #cdd6f4);
+  --color-primary-light: var(--accent-soft);
+  --color-success: #a6e3a1;
+  --color-success-light: rgba(166, 227, 161, 0.16);
+  --color-warning: #f9e2af;
+  --color-error: #f38ba8;
+  --color-error-muted: #eba0ac;
+  --color-danger: #f38ba8;
+  --color-danger-bg: rgba(243, 139, 168, 0.16);
+  --color-info: #89dceb;
+
+  /* Interaction, overlay, and native controls */
+  --hover-bg: color-mix(in srgb, var(--accent) 12%, transparent);
+  --selected-bg: color-mix(in srgb, var(--accent) 20%, var(--canvas));
+  --focus-ring: color-mix(in srgb, var(--accent) 35%, transparent);
+  --chip-bg: color-mix(in srgb, var(--accent) 16%, transparent);
+  --tag-bg: color-mix(in srgb, var(--accent) 10%, transparent);
+  --tag-border: color-mix(in srgb, var(--accent) 45%, transparent);
+  --surface-bg: rgba(205, 214, 244, 0.06);
+  --surface-bg-strong: rgba(205, 214, 244, 0.1);
+  --error-bg: rgba(243, 139, 168, 0.12);
+  --error-bg-strong: rgba(243, 139, 168, 0.2);
+  --error-border: rgba(243, 139, 168, 0.45);
+  --color-overlay: rgba(17, 17, 27, 0.72);
+  --color-focus: var(--accent);
+  --color-current-time: #f38ba8;
+  --day-cell-today-bg: color-mix(in srgb, var(--accent) 14%, var(--canvas));
+  --day-cell-hover-bg: color-mix(in srgb, var(--accent) 10%, var(--canvas));
+  --day-number-hover-bg: color-mix(in srgb, var(--accent) 18%, var(--canvas));
+  --day-column-today-bg: color-mix(in srgb, var(--accent) 6%, var(--canvas));
+
+  /* Elevated UI */
+  --modal-bg: #181825;
+  --popover-bg: #313244;
+  --modal-scrim: var(--color-overlay);
+  --modal-blur: blur(4px);
+  --modal-border: #45475a;
+  --modal-card-border: 1px solid #45475a;
+  --popover-border: #45475a;
+  --modal-shadow: 0 20px 60px rgba(17, 17, 27, 0.6), 0 2px 6px rgba(17, 17, 27, 0.4);
+
+  /* Supporting component tokens */
+  --ink-raw: 205, 214, 244;
+  --event-bg-mix: 24%;
+  --event-bg-mix-hover: 30%;
+  --event-rail-mix: 100%;
+  --event-marker-mix: 100%;
+  --color-scrollbar: #45475a;
+  --color-scrollbar-hover: #585b70;
+  --shadow-event: 0 1px 2px rgba(17, 17, 27, 0.24);
+  --shadow-event-hover: 0 4px 12px rgba(17, 17, 27, 0.36);
+  --shadow-card: 0 2px 8px rgba(17, 17, 27, 0.28), 0 8px 20px rgba(17, 17, 27, 0.18);
+  --shadow-sidebar: none;
+  --shadow-topbar: none;
+  --shadow-today: inset 0 0 0 1.5px color-mix(in srgb, var(--accent) 68%, transparent);
+  --shadow-glass: inset 0 1px 0 rgba(205, 214, 244, 0.06);
+  --shadow-inset: inset 0 1px 2px rgba(17, 17, 27, 0.3);
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -11,6 +11,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   const themeMode = useSettingsStore((s) => s.themeMode)
   const lightTheme = useSettingsStore((s) => s.lightTheme)
   const darkTheme = useSettingsStore((s) => s.darkTheme)
+  const mochaAccent = useSettingsStore((s) => s.mochaAccent)
   const [loadedThemes, setLoadedThemes] = useState<ThemeInfo[]>([])
   const [, setTick] = useState(0)
 
@@ -61,6 +62,11 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
     document.documentElement.setAttribute('data-theme', effectiveMode)
     document.documentElement.setAttribute('data-theme-mode', themeMode)
+    if (currentThemeId === 'catppuccin-mocha') {
+      document.documentElement.style.setProperty('--accent-custom', mochaAccent)
+    } else {
+      document.documentElement.style.removeProperty('--accent-custom')
+    }
     if (!isBuiltIn) {
       const themeId = currentThemeId.replace(/-(light|dark)$/, '')
       document.documentElement.setAttribute('data-theme-id', themeId)
@@ -74,7 +80,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     if (metaThemeColor) {
       metaThemeColor.setAttribute('content', accentColor || '#4285f4')
     }
-  }, [combinedCSS, effectiveMode, themeMode, currentThemeId, isBuiltIn])
+  }, [combinedCSS, effectiveMode, themeMode, currentThemeId, isBuiltIn, mochaAccent])
 
   const themeModeRef = useRef(themeMode)
   useEffect(() => {

--- a/src/features/calendar/components/CalendarGrid.module.css
+++ b/src/features/calendar/components/CalendarGrid.module.css
@@ -184,7 +184,7 @@
 
 .today .dayNumber {
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-contrast, #fff);
   font-weight: 600;
 }
 
@@ -215,7 +215,8 @@
 }
 
 .dayNumber:hover {
-  background: rgba(var(--ink-raw, 44, 40, 33), 0.06);
+  background: var(--day-number-hover-bg, var(--hover-bg));
+  color: var(--color-text-primary);
 }
 
 .dayNumber:active {

--- a/src/features/calendar/components/CurrentTimeIndicator.module.css
+++ b/src/features/calendar/components/CurrentTimeIndicator.module.css
@@ -17,7 +17,7 @@
   top: -8px;
   font-size: 10px;
   font-weight: 600;
-  color: #e53935;
+  color: var(--color-current-time, #e53935);
   white-space: nowrap;
   background: var(--panel, #ffffff);
   padding: 1px 4px;
@@ -32,8 +32,8 @@
   right: 0;
   top: 0;
   height: 2px;
-  background: #e53935;
-  box-shadow: 0 1px 3px rgba(229, 57, 53, 0.3);
+  background: var(--color-current-time, #e53935);
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--color-current-time, #e53935) 30%, transparent);
 }
 
 /* Small circle on the left edge (gutter) */
@@ -45,5 +45,5 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: #e53935;
+  background: var(--color-current-time, #e53935);
 }

--- a/src/features/calendar/components/DayView.module.css
+++ b/src/features/calendar/components/DayView.module.css
@@ -117,7 +117,7 @@
   width: 28px;
   height: 28px;
   background: var(--accent, #b07d4f);
-  color: white;
+  color: var(--accent-contrast, #fff);
   border-radius: 50%;
   font-weight: 600;
 }
@@ -169,7 +169,7 @@
 }
 
 .cell:hover {
-  background: rgba(var(--ink-raw, 44, 40, 33), 0.03);
+  background: var(--hover-bg);
 }
 
 .cell:active {

--- a/src/features/calendar/components/EventCard.module.css
+++ b/src/features/calendar/components/EventCard.module.css
@@ -81,7 +81,7 @@
   bottom: 4px;
   width: 3px;
   border-radius: 3px;
-  background: color-mix(in srgb, var(--event-color, var(--accent)) 50%, var(--canvas, #fff));
+  background: color-mix(in srgb, var(--event-color, var(--accent)) var(--event-rail-mix, 50%), var(--canvas, #fff));
 }
 
 .compact::before {

--- a/src/features/calendar/components/Sidebar.module.css
+++ b/src/features/calendar/components/Sidebar.module.css
@@ -320,7 +320,7 @@
 
 .miniDay.selected {
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-contrast, #fff);
   font-weight: 600;
 }
 

--- a/src/features/calendar/components/TodoView.module.css
+++ b/src/features/calendar/components/TodoView.module.css
@@ -323,7 +323,7 @@
   height: 20px;
   border-radius: 50%;
   cursor: pointer;
-  border: 1.7px solid color-mix(in srgb, var(--event-color, var(--accent)) 55%, var(--ink-3, #a39d93));
+  border: 1.7px solid color-mix(in srgb, var(--event-color, var(--accent)) var(--event-marker-mix, 55%), var(--ink-3, #a39d93));
   background: transparent;
   display: grid;
   place-content: center;
@@ -345,7 +345,7 @@
 
 .taskRow:hover .taskCheck {
   border-color: var(--event-color, var(--accent));
-  background: color-mix(in srgb, var(--event-color, var(--accent)) 9%, transparent);
+  background: color-mix(in srgb, var(--event-color, var(--accent)) var(--event-bg-mix, 9%), transparent);
 }
 
 .taskRow:hover .taskCheck svg {

--- a/src/features/calendar/components/WeekView.module.css
+++ b/src/features/calendar/components/WeekView.module.css
@@ -142,7 +142,7 @@
 }
 
 .dayHeader.today {
-  background: rgba(176, 125, 79, 0.04);
+  background: var(--day-column-today-bg, var(--selected-bg));
 }
 
 .dayHeader.today .dayNumber {
@@ -152,7 +152,7 @@
   width: 28px;
   height: 28px;
   background: var(--accent, #b07d4f);
-  color: white;
+  color: var(--accent-contrast, #fff);
   border-radius: 50%;
   font-weight: 600;
 }
@@ -200,7 +200,7 @@
 }
 
 .dayColumn.todayColumn {
-  background: rgba(176, 125, 79, 0.02);
+  background: var(--day-column-today-bg, var(--selected-bg));
 }
 
 .hourCells {
@@ -219,7 +219,7 @@
 }
 
 .cell:hover {
-  background: rgba(var(--ink-raw), 0.03);
+  background: var(--hover-bg);
 }
 
 .cell:active {

--- a/src/features/calendar/components/YearView.module.css
+++ b/src/features/calendar/components/YearView.module.css
@@ -153,7 +153,7 @@
 
 .today {
   background: var(--accent, #b07d4f);
-  color: #fff;
+  color: var(--accent-contrast, #fff);
   font-weight: 600;
 }
 
@@ -174,5 +174,5 @@
 }
 
 .today .eventDot {
-  background: #fff;
+  background: var(--accent-contrast, #fff);
 }

--- a/src/features/commandPalette/__tests__/useCommandPalette.test.ts
+++ b/src/features/commandPalette/__tests__/useCommandPalette.test.ts
@@ -132,6 +132,7 @@ vi.mock('@/store/settingsStore', () => ({
       themeMode: 'auto',
       lightTheme: 'default',
       darkTheme: 'default',
+      mochaAccent: '#89b4fa',
       caldavDebugMode: false,
       hideCompletedTasksInMonthView: true,
       monthViewEventLimit: 3,

--- a/src/features/settings/components/Settings.module.css
+++ b/src/features/settings/components/Settings.module.css
@@ -724,6 +724,35 @@
   line-height: 1.2;
 }
 
+.mochaAccentOptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.mochaAccentOption {
+  width: 24px;
+  height: 24px;
+  border: 2px solid transparent;
+  border-radius: 50%;
+  background: var(--mocha-accent);
+  cursor: pointer;
+}
+
+.mochaAccentOption:hover,
+.mochaAccentOption:focus-visible {
+  transform: scale(1.1);
+}
+
+.mochaAccentOption:focus-visible {
+  outline: 2px solid var(--color-text-primary);
+  outline-offset: 2px;
+}
+
+.mochaAccentOptionActive {
+  border-color: var(--color-text-primary);
+}
+
 /* ── Accent Color Swatches ──────────────────────────────────────────────── */
 .swatches {
   display: flex;

--- a/src/features/settings/components/ThemeSettings.tsx
+++ b/src/features/settings/components/ThemeSettings.tsx
@@ -1,10 +1,20 @@
 import { useEffect, useMemo } from 'react'
-import type { JSX } from 'react'
+import type { CSSProperties, JSX } from 'react'
 import { useSettingsStore, THEME_MODE_OPTIONS } from '@/store/settingsStore'
 import { useTheme } from '@/components/ThemeContext'
 import { getThemePreviewCSS } from '@/lib/themes'
 import type { ThemeMode } from '@/types'
 import styles from './Settings.module.css'
+
+const MOCHA_ACCENTS = [
+  { label: 'Blue', value: '#89b4fa' },
+  { label: 'Lavender', value: '#b4befe' },
+  { label: 'Mauve', value: '#cba6f7' },
+  { label: 'Pink', value: '#f5c2e7' },
+  { label: 'Teal', value: '#94e2d5' },
+  { label: 'Green', value: '#a6e3a1' },
+  { label: 'Peach', value: '#fab387' },
+]
 
 function MiniCalendarPreview({ themeId, variant }: { themeId: string; variant: 'light' | 'dark' | 'system' }): JSX.Element {
   // Extract theme colors from the theme's CSS (dynamically reflects the selected theme)
@@ -96,6 +106,7 @@ export function ThemeSettings(): JSX.Element {
   const themeMode = useSettingsStore((s) => s.themeMode)
   const lightTheme = useSettingsStore((s) => s.lightTheme)
   const darkTheme = useSettingsStore((s) => s.darkTheme)
+  const mochaAccent = useSettingsStore((s) => s.mochaAccent)
   const updateSettings = useSettingsStore((s) => s.updateSettings)
   const showEventIcons = useSettingsStore((s) => s.showEventIcons)
   const { loadedThemes, refetchThemes } = useTheme()
@@ -185,6 +196,28 @@ export function ThemeSettings(): JSX.Element {
             />
           ))}
         </div>
+        {darkTheme === 'catppuccin-mocha' && (
+          <div className={styles.row} data-component="setting-row" data-setting="mocha-accent">
+            <div className={styles.rowInfo}>
+              <div className={styles.rowLabel}>Catppuccin accent</div>
+              <div className={styles.rowDesc}>Used for selection, focus, and primary actions</div>
+            </div>
+            <div className={styles.mochaAccentOptions} role="group" aria-label="Catppuccin accent color">
+              {MOCHA_ACCENTS.map((accent) => (
+                <button
+                  key={accent.value}
+                  className={`${styles.mochaAccentOption} ${mochaAccent === accent.value ? styles.mochaAccentOptionActive : ''}`}
+                  style={{ '--mocha-accent': accent.value } as CSSProperties}
+                  onClick={() => updateSettings({ mochaAccent: accent.value })}
+                  aria-label={`Use ${accent.label} accent`}
+                  aria-pressed={mochaAccent === accent.value}
+                  title={accent.label}
+                  type="button"
+                />
+              ))}
+            </div>
+          </div>
+        )}
         <div className={styles.row} data-component="setting-row" data-setting="show-event-icons" data-value={String(showEventIcons)}>
           <div className={styles.rowInfo}>
             <div className={styles.rowLabel}>Event icons</div>

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -119,6 +119,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   themeMode: 'auto' as ThemeMode,
   lightTheme: config.defaultLightTheme,
   darkTheme: config.defaultDarkTheme,
+  mochaAccent: '#89b4fa',
   caldavDebugMode: false,
   hideCompletedTasksInMonthView: true,
   useCategoryColors: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -270,6 +270,7 @@ export interface UserSettings {
   themeMode: ThemeMode
   lightTheme: string
   darkTheme: string
+  mochaAccent: string
   caldavDebugMode: boolean
   hideCompletedTasksInMonthView: boolean
   useCategoryColors: boolean


### PR DESCRIPTION
## Summary

Adds the Catppuccin theme to Calino, with configurable accents and consistent visual tokens across calendar views.

## Changes

- Adds the Catppuccin dark theme.
- Allows selecting and persisting seven accent colors.
- Applies proper contrast colors to selected dates.
- Updates hover states, the current-time indicator, and event backgrounds.
- Uses the actual calendar color for event and task markers.
- Prevents a background flash during initial load.
- Adds E2E coverage for theme selection, persistence, and rendering.

## Validation

- `pnpm typecheck` passed.
- `pnpm lint` passed with pre-existing warnings.
- `pnpm exec playwright test e2e/native-controls-theme.spec.ts` passed.
- `git diff --check` passed.


<img width="1867" height="957" alt="image" src="https://github.com/user-attachments/assets/1e36dd1c-19df-4066-97d4-c77035e20f25" />
<img width="1867" height="957" alt="image" src="https://github.com/user-attachments/assets/9888fd6b-e4cd-441f-accf-4a162056362c" />
<img width="1867" height="957" alt="image" src="https://github.com/user-attachments/assets/55c17acf-21d5-4d70-9ef1-06ae884f93d7" />
<img width="1867" height="957" alt="image" src="https://github.com/user-attachments/assets/0a8f02fb-dc0a-4cbe-915a-b688ddf8c4be" />
