### PR TITLE
Fix recurring event sync and add future occurrence deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 .env
 .env.local
 .env.*.local
+e2e/.env.test
 
 # Self-hosted config (contains encrypted credentials)
 calino.config.json

--- a/e2e/calendar-sync.spec.ts
+++ b/e2e/calendar-sync.spec.ts
@@ -96,4 +96,222 @@ END:VCALENDAR`,
 
     await expect(page.locator('#priority-select')).toHaveValue('')
   })
+
+  test('edits a recurring event at its original CalDAV href without duplicating it', async ({
+    page,
+    baseURL,
+  }) => {
+    await clearState(page)
+    await seedAccount(page, {
+      id: 'mock-account',
+      name: 'Mock Radicale',
+      serverUrl: `${baseURL}/mock-caldav/dav/`,
+      username: 'user',
+      password: 'pass',
+    })
+
+    const date = new Date()
+    const day = date.toISOString().slice(0, 10).replaceAll('-', '')
+    const calendarUrl = `${baseURL}/mock-caldav/dav/calendars/user/personal/`
+    const originalHref = `${calendarUrl}server-generated-name.ics`
+    await page.request.put(originalHref, {
+      data: `BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:recurring-remote-uid\r\nDTSTART:${day}T120000Z\r\nDTEND:${day}T130000Z\r\nRRULE:FREQ=WEEKLY\r\nSUMMARY:Remote recurring event\r\nSEQUENCE:0\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n`,
+    })
+
+    const seededReport = await page.request.fetch(calendarUrl, {
+      method: 'REPORT',
+      data: '<calendar-query xmlns="urn:ietf:params:xml:ns:caldav"/>',
+      headers: { Depth: '1', 'Content-Type': 'application/xml' },
+    })
+    expect(await seededReport.text()).toContain('Remote recurring event')
+
+    await page.goto('/month')
+    await page.locator('[data-component="sync-all-calendars"]').click()
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const stored = JSON.parse(localStorage.getItem('calino-storage') ?? '{}')
+            return (stored.state?.events ?? []).map((event: { title: string }) => event.title)
+          }),
+        { timeout: 10_000 }
+      )
+      .toContain('Remote recurring event')
+    const eventCard = page
+      .locator('[data-component="event-card"]')
+      .filter({ hasText: 'Remote recurring event' })
+      .first()
+    await expect(eventCard).toBeVisible({ timeout: 10_000 })
+    await eventCard.click()
+    await page
+      .locator('[data-component="event-preview"]')
+      .getByRole('button', { name: /Open event/i })
+      .click()
+    await page
+      .locator('[data-component="event-title-input"]')
+      .fill('Remote recurring event updated')
+    await page.locator('[data-component="modal-save"]').click()
+
+    const recurrenceDialog = page.getByRole('dialog').filter({ hasText: /Edit recurring event/i })
+    await recurrenceDialog.getByRole('button', { name: /All events/i }).click()
+    await expect(page.getByText('Remote recurring event updated').first()).toBeVisible()
+
+    const report = await page.request.fetch(calendarUrl, {
+      method: 'REPORT',
+      data: '<calendar-query xmlns="urn:ietf:params:xml:ns:caldav"/>',
+      headers: { Depth: '1', 'Content-Type': 'application/xml' },
+    })
+    const body = await report.text()
+    expect(body).toContain('server-generated-name.ics')
+    expect(body).toContain('SUMMARY:Remote recurring event updated')
+    expect(body.match(/UID:recurring-remote-uid/g)).toHaveLength(1)
+  })
+
+  test('shows a recurring occurrence moved by another CalDAV client', async ({ page, baseURL }) => {
+    await clearState(page)
+    await seedAccount(page, {
+      id: 'moved-occurrence-account',
+      name: 'Mock Radicale',
+      serverUrl: `${baseURL}/mock-caldav/dav/`,
+      username: 'user',
+      password: 'pass',
+    })
+
+    const original = new Date()
+    original.setUTCHours(9, 0, 0, 0)
+    const moved = new Date(original)
+    moved.setUTCDate(moved.getUTCDate() + 1)
+    moved.setUTCHours(11, 0, 0, 0)
+    const formatIcal = (date: Date) => date.toISOString().replace(/[-:]/g, '').replace('.000', '')
+    const calendarUrl = `${baseURL}/mock-caldav/dav/calendars/user/personal/`
+    await page.request.put(`${calendarUrl}external-moved-series.ics`, {
+      data: `BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:external-moved-series\r\nDTSTART:${formatIcal(original)}\r\nDTEND:${formatIcal(new Date(original.getTime() + 3600000))}\r\nRRULE:FREQ=WEEKLY\r\nSUMMARY:External weekly meeting\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nUID:external-moved-series\r\nRECURRENCE-ID:${formatIcal(original)}\r\nDTSTART:${formatIcal(moved)}\r\nDTEND:${formatIcal(new Date(moved.getTime() + 3600000))}\r\nSUMMARY:Moved by external client\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n`,
+    })
+
+    await page.goto('/month')
+    await page.locator('[data-component="sync-all-calendars"]').click()
+
+    await expect(
+      page.locator('[data-component="event-card"]').filter({ hasText: 'Moved by external client' })
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('does not apply a midnight EXDATE to a timed occurrence', async ({ page, baseURL }) => {
+    await clearState(page)
+    await seedAccount(page, {
+      id: 'timed-exdate-account',
+      name: 'Mock Radicale',
+      serverUrl: `${baseURL}/mock-caldav/dav/`,
+      username: 'user',
+      password: 'pass',
+    })
+
+    const first = new Date()
+    first.setUTCHours(15, 20, 0, 0)
+    const second = new Date(first)
+    second.setUTCDate(second.getUTCDate() + 1)
+    const midnightExdate = new Date(second)
+    midnightExdate.setUTCHours(0, 0, 0, 0)
+    const formatIcal = (date: Date) => date.toISOString().replace(/[-:]/g, '').replace('.000', '')
+    const calendarUrl = `${baseURL}/mock-caldav/dav/calendars/user/personal/`
+    await page.request.put(`${calendarUrl}timed-midnight-exdate.ics`, {
+      data: `BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:timed-midnight-exdate\r\nDTSTART:${formatIcal(first)}\r\nDTEND:${formatIcal(new Date(first.getTime() + 3000000))}\r\nRRULE:FREQ=DAILY;COUNT=2\r\nEXDATE:${formatIcal(midnightExdate)}\r\nSUMMARY:Timed EXDATE regression\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n`,
+    })
+
+    await page.goto('/agenda')
+    await page.locator('[data-component="sync-all-calendars"]').click()
+
+    await expect(
+      page.locator('main').getByText('Timed EXDATE regression', { exact: true })
+    ).toHaveCount(2, {
+      timeout: 10_000,
+    })
+  })
+
+  test('persists a single-occurrence edit in the master CalDAV resource', async ({
+    page,
+    baseURL,
+  }) => {
+    await clearState(page)
+    await seedAccount(page, {
+      id: 'atomic-override-account',
+      name: 'Mock Radicale',
+      serverUrl: `${baseURL}/mock-caldav/dav/`,
+      username: 'user',
+      password: 'pass',
+    })
+
+    const occurrence = new Date()
+    occurrence.setUTCHours(15, 20, 0, 0)
+    const formatIcal = (date: Date) => date.toISOString().replace(/[-:]/g, '').replace('.000', '')
+    const calendarUrl = `${baseURL}/mock-caldav/dav/calendars/user/personal/`
+    await page.request.put(`${calendarUrl}atomic-series.ics`, {
+      data: `BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:atomic-series\r\nDTSTART:${formatIcal(occurrence)}\r\nDTEND:${formatIcal(new Date(occurrence.getTime() + 3000000))}\r\nRRULE:FREQ=WEEKLY\r\nSUMMARY:Atomic recurring master\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n`,
+    })
+
+    await page.goto('/month')
+    await page.locator('[data-component="sync-all-calendars"]').click()
+    const card = page
+      .locator('[data-component="event-card"]')
+      .filter({ hasText: 'Atomic recurring master' })
+      .first()
+    await expect(card).toBeVisible({ timeout: 10_000 })
+    await card.click()
+    await page
+      .locator('[data-component="event-preview"]')
+      .getByRole('button', { name: /Open event/i })
+      .click()
+    await page.locator('[data-component="event-title-input"]').fill('Atomic recurring override')
+    await page.locator('[data-component="modal-save"]').click()
+    const dialog = page.getByRole('dialog').filter({ hasText: /Edit recurring event/i })
+    await dialog.getByRole('button', { name: /This event only/i }).click()
+    await expect(
+      page
+        .locator('[data-component="event-card"]')
+        .filter({ hasText: 'Atomic recurring override' })
+        .first()
+    ).toBeVisible({ timeout: 10_000 })
+
+    const report = await page.request.fetch(calendarUrl, {
+      method: 'REPORT',
+      data: '<calendar-query xmlns="urn:ietf:params:xml:ns:caldav"/>',
+      headers: { Depth: '1', 'Content-Type': 'application/xml' },
+    })
+    const body = await report.text()
+    expect(body.match(/UID:atomic-series/g)).toHaveLength(2)
+    expect(body).toContain('RECURRENCE-ID:')
+    expect(body).toContain('SUMMARY:Atomic recurring override')
+
+    await page.reload()
+    await page.locator('[data-component="sync-all-calendars"]').click()
+    await expect(
+      page
+        .locator('[data-component="event-card"]')
+        .filter({ hasText: 'Atomic recurring override' })
+        .first()
+    ).toBeVisible({ timeout: 10_000 })
+
+    const importedOverride = page
+      .locator('[data-component="event-card"]')
+      .filter({ hasText: 'Atomic recurring override' })
+      .first()
+    await importedOverride.click()
+    await page
+      .locator('[data-component="event-preview"]')
+      .getByRole('button', { name: 'Delete' })
+      .click()
+    const deleteDialog = page.getByRole('dialog').filter({ hasText: /Delete recurring event/i })
+    await deleteDialog.getByRole('button', { name: /This event only/i }).click()
+    await expect(importedOverride).toBeHidden()
+
+    const reportAfterDelete = await page.request.fetch(calendarUrl, {
+      method: 'REPORT',
+      data: '<calendar-query xmlns="urn:ietf:params:xml:ns:caldav"/>',
+      headers: { Depth: '1', 'Content-Type': 'application/xml' },
+    })
+    const bodyAfterDelete = await reportAfterDelete.text()
+    expect(bodyAfterDelete.match(/UID:atomic-series/g)).toHaveLength(1)
+    expect(bodyAfterDelete).not.toContain('SUMMARY:Atomic recurring override')
+    expect(bodyAfterDelete).toContain('EXDATE:')
+  })
 })

--- a/e2e/categories.spec.ts
+++ b/e2e/categories.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { clearState } from './fixtures/localstorage'
+import { clearState, seedRecurringEvent } from './fixtures/localstorage'
 
 async function setColorInputValue(
   page: import('@playwright/test').Page,
@@ -48,5 +48,42 @@ test.describe('category colors', () => {
     const persistedCategory = page.locator('[data-component="category-row"]', { hasText: 'Personal' })
     await persistedCategory.getByText('Personal', { exact: true }).click()
     await expect(page.getByLabel('Custom color for category Personal')).toHaveValue('#654321')
+  })
+
+  test('keeps a category when re-editing one occurrence of a recurring event', async ({ page }) => {
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+    const fmt = (date: Date) =>
+      `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+
+    await seedRecurringEvent(page, {
+      id: 'categorized-series', title: 'Recurring category test',
+      startDate: fmt(yesterday), endDate: fmt(yesterday), startTime: '10:00', endTime: '11:00',
+      frequency: 'daily', interval: 1,
+    })
+    await page.goto('/settings')
+    await page.getByRole('button', { name: 'Categories' }).click()
+    await page.locator('[data-action="add-category"]').click()
+    await page.getByLabel('New category name').fill('Work')
+    await page.locator('[data-component="add-category-form"]').getByRole('button', { name: 'Add' }).click()
+
+    await page.goto('/day')
+    const occurrence = page.getByRole('button', { name: /Recurring category test/ }).first()
+    await occurrence.click()
+    await page.locator('[data-component="event-preview"]').getByRole('button', { name: /Open event/ }).click()
+    await page.locator('[data-component="event-title-input"]').fill('Detached category test')
+    await page.locator('[data-component="modal-save"]').click()
+    await page.getByRole('dialog').filter({ hasText: /Edit recurring event/ })
+      .getByRole('button', { name: /This event only/ }).click()
+
+    const detached = page.getByRole('button', { name: /Detached category test/ }).first()
+    await detached.click()
+    await page.locator('[data-component="event-preview"]').getByRole('button', { name: /Open event/ }).click()
+    await page.getByRole('button', { name: 'Work' }).click()
+    await page.locator('[data-component="modal-save"]').click()
+
+    await detached.click()
+    await page.locator('[data-component="event-preview"]').getByRole('button', { name: /Open event/ }).click()
+    await expect(page.getByRole('button', { name: 'Work' })).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/e2e/categories.spec.ts
+++ b/e2e/categories.spec.ts
@@ -78,11 +78,18 @@ test.describe('category colors', () => {
 
     const detached = page.getByRole('button', { name: /Detached category test/ }).first()
     await detached.click()
-    await page.locator('[data-component="event-preview"]').getByRole('button', { name: /Open event/ }).click()
+    const preview = page.locator('[data-component="event-preview"]')
+    await preview.getByText('Detached category test', { exact: true }).click()
+    await preview.locator('input[type="text"]').fill('Detached category test updated')
+    await preview.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByText('Edit recurring event')).toBeHidden()
+    await expect(preview.getByText('Detached category test updated', { exact: true })).toBeVisible()
+
+    await preview.getByRole('button', { name: /Open event/ }).click()
     await page.getByRole('button', { name: 'Work' }).click()
     await page.locator('[data-component="modal-save"]').click()
 
-    await detached.click()
+    await page.getByRole('button', { name: /Detached category test updated/ }).first().click()
     await page.locator('[data-component="event-preview"]').getByRole('button', { name: /Open event/ }).click()
     await expect(page.getByRole('button', { name: 'Work' })).toHaveAttribute('aria-pressed', 'true')
   })

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -210,6 +210,42 @@ test.describe('smoke', () => {
     ).toBeVisible({ timeout: 5_000 })
   })
 
+  test('delete "This and following events" keeps earlier occurrences', async ({ page }) => {
+    const today = new Date()
+    const yesterday = new Date(today)
+    yesterday.setDate(yesterday.getDate() - 1)
+    const fmt = (date: Date) =>
+      `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+
+    await seedRecurringEvent(page, {
+      id: 'daily-cleanup',
+      title: 'Daily Cleanup',
+      startDate: fmt(yesterday),
+      endDate: fmt(yesterday),
+      startTime: '10:00',
+      endTime: '11:00',
+      frequency: 'daily',
+      interval: 1,
+    })
+
+    await page.goto('/day')
+    const currentOccurrence = page.getByRole('button', { name: /Daily Cleanup/ }).first()
+    await expect(currentOccurrence).toBeVisible({ timeout: 10_000 })
+    await currentOccurrence.click()
+    const preview = page.locator('[data-component="event-preview"]')
+    await preview.getByRole('button', { name: /Open event/i }).click()
+    await page.locator('[data-component="modal-card"]').getByRole('button', { name: 'Delete' }).click()
+
+    const dialog = page.getByRole('dialog').filter({ hasText: /Delete recurring event/i })
+    const futureButton = dialog.getByRole('button', { name: /This and following events/i })
+    await expect(futureButton).toBeVisible()
+    await futureButton.click()
+
+    await expect(currentOccurrence).toBeHidden()
+    await page.getByRole('button', { name: 'Previous', exact: true }).click()
+    await expect(page.getByRole('button', { name: /Daily Cleanup/ }).first()).toBeVisible()
+  })
+
   test('command palette opens via search button and a natural-language event is created', async ({
     page,
   }) => {

--- a/src/features/caldav/adapter/__tests__/iCalendarAdapter.test.ts
+++ b/src/features/caldav/adapter/__tests__/iCalendarAdapter.test.ts
@@ -415,6 +415,40 @@ END:VCALENDAR`
       expect(events[0].recurrenceId).toContain('T14:00:00')
     })
 
+    it('preserves a recurring master and its detached override with the same UID', () => {
+      const iCal = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:shared-series
+DTSTART:20240318T090000Z
+DTEND:20240318T100000Z
+RRULE:FREQ=WEEKLY
+SUMMARY:Weekly meeting
+END:VEVENT
+BEGIN:VEVENT
+UID:shared-series
+RECURRENCE-ID:20240325T090000Z
+DTSTART:20240326T110000Z
+DTEND:20240326T120000Z
+SUMMARY:Moved meeting
+STATUS:CANCELLED
+END:VEVENT
+END:VCALENDAR`
+
+      const events = parseICALEvent(iCal, 'cal-1')
+
+      expect(events).toHaveLength(2)
+      expect(events[0]).toMatchObject({ id: 'shared-series', uid: 'shared-series' })
+      expect(events[1]).toMatchObject({
+        uid: 'shared-series',
+        recurrenceMasterId: 'shared-series',
+        eventStatus: 'CANCELLED',
+        title: 'Moved meeting',
+      })
+      expect(events[1].id).not.toBe(events[0].id)
+      expect(eventToICAL(events[1])).toContain('STATUS:CANCELLED')
+    })
+
     it('handles multiple events in one iCal', () => {
       const iCal = `BEGIN:VCALENDAR
 VERSION:2.0
@@ -1227,7 +1261,7 @@ END:VCALENDAR`
         ].join('\r\n')
 
         const events = parseICALEvent(ics, 'cal-1')
-        const exception = events.find((e) => e.id === 'exception-tzid')
+        const exception = events.find((e) => e.uid === 'exception-tzid')
         expect(exception).toBeDefined()
         expect(exception!.timezone).toBe('America/New_York')
         expect(exception!.recurrenceId).toBe('2025-07-13T15:00:00')

--- a/src/features/caldav/adapter/iCalendarAdapter.ts
+++ b/src/features/caldav/adapter/iCalendarAdapter.ts
@@ -151,7 +151,13 @@ export function eventsToICAL(events: CalendarEvent[]): string {
   comp.updatePropertyWithValue('calscale', 'GREGORIAN')
 
   for (const event of events) {
-    comp.addSubcomponent(calendarEventToIcalComponent(event))
+    comp.addSubcomponent(
+      event.type === 'task'
+        ? calendarEventToIcalVtodo(event)
+        : event.type === 'journal'
+          ? calendarEventToIcalVjournal(event)
+          : calendarEventToIcalComponent(event)
+    )
   }
 
   return foldICalLines(comp.toString())

--- a/src/features/caldav/adapter/iCalendarAdapter.ts
+++ b/src/features/caldav/adapter/iCalendarAdapter.ts
@@ -36,28 +36,12 @@ export function parseICALEvent(iCalData: string, calendarId: string): CalendarEv
   }
 
   const vevents = comp.getAllSubcomponents('vevent')
-  const uidToIndex = new Map<string, number>()
   const events: CalendarEvent[] = []
 
   for (const vevent of vevents) {
     try {
       const event = icalEventToCalendarEvent(vevent, calendarId)
-      const uid = event.id
-
-      if (uid) {
-        const existingIndex = uidToIndex.get(uid)
-        if (existingIndex !== undefined) {
-          const existing = events[existingIndex]
-          if (!existing.rruleString && event.rruleString) {
-            events[existingIndex] = event
-          }
-        } else {
-          uidToIndex.set(uid, events.length)
-          events.push(event)
-        }
-      } else {
-        events.push(event)
-      }
+      events.push(event)
     } catch (e) {
       console.error('Failed to parse vevent:', e)
       continue
@@ -157,13 +141,18 @@ export function foldICalLines(s: string): string {
 }
 
 export function eventToICAL(event: CalendarEvent): string {
+  return eventsToICAL([event])
+}
+
+export function eventsToICAL(events: CalendarEvent[]): string {
   const comp = new ICAL.Component('vcalendar')
   comp.updatePropertyWithValue('version', '2.0')
   comp.updatePropertyWithValue('prodid', '-//Calino//EN')
   comp.updatePropertyWithValue('calscale', 'GREGORIAN')
 
-  const vevent = calendarEventToIcalComponent(event)
-  comp.addSubcomponent(vevent)
+  for (const event of events) {
+    comp.addSubcomponent(calendarEventToIcalComponent(event))
+  }
 
   return foldICalLines(comp.toString())
 }

--- a/src/features/caldav/adapter/icalTypeMapping.ts
+++ b/src/features/caldav/adapter/icalTypeMapping.ts
@@ -571,8 +571,13 @@ export function icalEventToCalendarEvent(
     }
   }
 
+  const uid = event.uid || uuidv4()
+  const statusValue = vevent.getFirstPropertyValue('status')
+  const eventStatus = typeof statusValue === 'string' ? statusValue.toUpperCase() : undefined
+
   return {
-    id: event.uid || uuidv4(),
+    id: recurrenceId ? `${uid}-${recurrenceId}` : uid,
+    uid,
     calendarId,
     title: event.summary || 'Untitled',
     description: event.description,
@@ -592,6 +597,8 @@ export function icalEventToCalendarEvent(
     sequence,
     excludedDates: excludedDates.length > 0 ? excludedDates : undefined,
     recurrenceId,
+    recurrenceMasterId: recurrenceId ? uid : undefined,
+    eventStatus,
     attachments: attachments.length > 0 ? attachments : undefined,
   }
 }
@@ -659,9 +666,12 @@ function createAllDayDate(year: number, month: number, day: number): ICAL.Time {
 export function calendarEventToIcalComponent(event: CalendarEvent): ICAL.Component {
   const vevent = new ICAL.Component('vevent')
 
-  vevent.updatePropertyWithValue('uid', event.id)
+  vevent.updatePropertyWithValue('uid', event.uid || event.recurrenceMasterId || event.id)
   vevent.updatePropertyWithValue('dtstamp', ICAL.Time.fromJSDate(new Date(), true))
   vevent.updatePropertyWithValue('sequence', event.sequence ?? 0)
+  if (event.eventStatus) {
+    vevent.updatePropertyWithValue('status', event.eventStatus)
+  }
 
   if (event.isAllDay) {
     const startParts = event.start.split('T')[0].split('-')

--- a/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
+++ b/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
@@ -644,6 +644,70 @@ describe('useCalDAV', () => {
     })
   })
 
+  describe('saveRecurrenceOverride', () => {
+    beforeEach(() => {
+      mockAccountStorage.getAllAccounts.mockReturnValue([mockAccount])
+      mockAccountStorage.getAllCalendars.mockReturnValue([mockCalendar])
+    })
+
+    it('removes future overrides from the grouped CalDAV resource and local store', async () => {
+      const master: CalendarEvent = {
+        ...mockEvent,
+        id: 'series',
+        uid: 'series',
+        recurrence: { frequency: 'daily', interval: 1 },
+      }
+      const past: CalendarEvent = {
+        ...mockEvent,
+        id: 'past',
+        uid: 'series',
+        recurrenceId: '2026-04-14T09:00:00Z',
+        recurrenceMasterId: master.id,
+      }
+      const selected: CalendarEvent = {
+        ...past,
+        id: 'selected',
+        recurrenceId: '2026-04-15T09:00:00Z',
+      }
+      const future: CalendarEvent = {
+        ...past,
+        id: 'future',
+        recurrenceId: '2026-04-16T09:00:00Z',
+      }
+      act(() => {
+        useCalendarStore.getState().addEvent(master)
+        useCalendarStore.getState().addEvent(past)
+        useCalendarStore.getState().addEvent(selected)
+        useCalendarStore.getState().addEvent(future)
+      })
+
+      const { result } = renderHook(() => useCalDAV())
+      await waitFor(() => expect(result.current.accounts.length).toBe(1))
+      await act(async () => {
+        await result.current.saveRecurrenceOverride(
+          'cal-1',
+          master,
+          null,
+          [selected.id, future.id]
+        )
+      })
+
+      expect(mockSyncEngineInstance.updateEventGroup).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ id: master.id }),
+          expect.objectContaining({ id: past.id }),
+        ]),
+        ''
+      )
+      const groupedEvents = mockSyncEngineInstance.updateEventGroup.mock.calls[0][0]
+      expect(groupedEvents.map((event: CalendarEvent) => event.id)).not.toContain(selected.id)
+      expect(groupedEvents.map((event: CalendarEvent) => event.id)).not.toContain(future.id)
+      expect(useCalendarStore.getState().events.some((event) => event.id === past.id)).toBe(true)
+      expect(useCalendarStore.getState().events.some((event) => event.id === selected.id)).toBe(false)
+      expect(useCalendarStore.getState().events.some((event) => event.id === future.id)).toBe(false)
+    })
+  })
+
   // -----------------------------------------------------------------------
   // deleteEvent (direct, not via pending changes)
   // -----------------------------------------------------------------------

--- a/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
+++ b/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
@@ -706,6 +706,41 @@ describe('useCalDAV', () => {
       expect(useCalendarStore.getState().events.some((event) => event.id === selected.id)).toBe(false)
       expect(useCalendarStore.getState().events.some((event) => event.id === future.id)).toBe(false)
     })
+
+    it('preserves unrelated events stored in the same CalDAV resource', async () => {
+      const resourceHref = `${mockCalendar.url}shared.ics`
+      const master: CalendarEvent = {
+        ...mockEvent, id: 'series', uid: 'series', resourceHref,
+        recurrence: { frequency: 'daily', interval: 1 },
+      }
+      const unrelated: CalendarEvent = {
+        ...mockEvent, id: 'unrelated', uid: 'unrelated', title: 'Must remain', resourceHref,
+      }
+      const exception: CalendarEvent = {
+        ...mockEvent, id: 'series-2026-04-15T09:00:00Z', uid: 'series', resourceHref,
+        recurrenceId: '2026-04-15T09:00:00Z', recurrenceMasterId: master.id, categories: ['Work'],
+      }
+      act(() => {
+        useCalendarStore.getState().addEvent(master)
+        useCalendarStore.getState().addEvent(unrelated)
+      })
+
+      const { result } = renderHook(() => useCalDAV())
+      await waitFor(() => expect(result.current.accounts.length).toBe(1))
+      await act(async () => {
+        await result.current.saveRecurrenceOverride('cal-1', master, exception)
+      })
+
+      const groupedEvents = mockSyncEngineInstance.updateEventGroup.mock.calls[0][0]
+      expect(groupedEvents).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: master.id }),
+        expect.objectContaining({ id: exception.id, categories: ['Work'] }),
+        expect.objectContaining({ id: unrelated.id, title: 'Must remain' }),
+      ]))
+      expect(useCalendarStore.getState().events.find((event) => event.id === unrelated.id)).toEqual(
+        expect.objectContaining({ resourceHref: 'https://series.ics', etag: 'group-etag' })
+      )
+    })
   })
 
   // -----------------------------------------------------------------------

--- a/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
+++ b/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
@@ -118,6 +118,7 @@ describe('useCalDAV', () => {
   let mockSyncEngineInstance: {
     pushEvent: ReturnType<typeof vi.fn>
     updateEvent: ReturnType<typeof vi.fn>
+    updateEventGroup: ReturnType<typeof vi.fn>
     deleteEvent: ReturnType<typeof vi.fn>
   }
 
@@ -171,6 +172,7 @@ describe('useCalDAV', () => {
     mockSyncEngineInstance = {
       pushEvent: vi.fn().mockResolvedValue({ url: 'https://...', etag: 'abc' }),
       updateEvent: vi.fn().mockResolvedValue({ url: 'https://...', etag: 'def' }),
+      updateEventGroup: vi.fn().mockResolvedValue({ url: 'https://series.ics', etag: 'group-etag' }),
       deleteEvent: vi.fn().mockResolvedValue(undefined),
     }
     mockSyncEngine.SyncEngine.mockImplementation(function () {
@@ -1548,6 +1550,28 @@ describe('useCalDAV', () => {
 
       const store = useCalendarStore.getState()
       expect(store.events.find((e) => e.id === 'server-new')).toBeDefined()
+    })
+
+    it('preserves the server resource URL and etag on imported events', async () => {
+      const serverEvent: CalendarEvent = { ...mockEvent, id: 'remote-uid' }
+      const resourceHref = `${mockCalendar.url}server-generated.ics`
+      const iCalendarAdapter = await import('../../adapter/iCalendarAdapter')
+      vi.mocked(iCalendarAdapter.parseICALData).mockReturnValue([serverEvent])
+      mockCalDAVClient.createCalDAVClient.mockResolvedValue({
+        fetchEvents: vi.fn().mockResolvedValue([
+          { url: resourceHref, data: 'ical-data', etag: '"remote-etag"' },
+        ]),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
+      } as any)
+
+      const { result } = renderHook(() => useCalDAV())
+      await waitFor(() => expect(result.current.accounts.length).toBe(1))
+      await act(async () => result.current.syncAccount(mockAccount.id))
+
+      expect(useCalendarStore.getState().events.find((event) => event.id === serverEvent.id)).toMatchObject({
+        resourceHref,
+        etag: '"remote-etag"',
+      })
     })
   })
 

--- a/src/features/caldav/hooks/useCalDAV.ts
+++ b/src/features/caldav/hooks/useCalDAV.ts
@@ -109,7 +109,14 @@ async function collectParsedWithHref(
           }
         }
       }
-      result.push({ event: parsedEvent, href: eventData.url })
+      result.push({
+        event: {
+          ...parsedEvent,
+          resourceHref: eventData.url,
+          etag: eventData.etag,
+        },
+        href: eventData.url,
+      })
     }
   }
   return { items: result, hadParseFailures }
@@ -143,6 +150,12 @@ interface UseCalDAVReturn {
   syncAll: () => Promise<void>
   createEvent: (calendarId: string, event: CalendarEvent) => Promise<void>
   updateEvent: (calendarId: string, event: CalendarEvent) => Promise<void>
+  saveRecurrenceOverride: (
+    calendarId: string,
+    master: CalendarEvent,
+    exception: CalendarEvent | null,
+    removedExceptionId?: string
+  ) => Promise<void>
   deleteEvent: (calendarId: string, eventId: string) => Promise<void>
   deleteEventByHref: (calendarId: string, href: string) => Promise<void>
   retryAllFailedSyncs: () => Promise<{ succeeded: number; failed: number }>
@@ -227,31 +240,45 @@ export function useCalDAV(): UseCalDAVReturn {
           switch (change.type) {
             case 'create': {
               const event = JSON.parse(change.data || '{}') as CalendarEvent
-              await engine.pushEvent({ ...event, sequence: 0 })
-              // Mark as synced in the store
-              storeUpdateEvent(change.eventId, { syncStatus: 'synced' })
+              const { url, etag } = await engine.pushEvent({ ...event, sequence: 0 })
+              storeUpdateEvent(change.eventId, { resourceHref: url, etag, syncStatus: 'synced' })
               break
             }
             case 'update': {
               const event = JSON.parse(change.data || '{}') as CalendarEvent
-              await engine.updateEvent(event, event.etag || '')
+              const state = useCalendarStore.getState()
+              const uid = event.uid || event.id
+              const overrides = !event.recurrenceId
+                ? state.events.filter(
+                    (candidate) =>
+                      candidate.calendarId === change.calendarId &&
+                      Boolean(candidate.recurrenceId) &&
+                      (candidate.uid === uid || candidate.recurrenceMasterId === event.id)
+                  )
+                : []
+              const { url, etag } =
+                overrides.length > 0
+                  ? await engine.updateEventGroup([event, ...overrides], event.etag || '')
+                  : await engine.updateEvent(event, event.etag || '')
               // Mark as synced in the store
-              storeUpdateEvent(change.eventId, { syncStatus: 'synced' })
+              storeUpdateEvent(change.eventId, { resourceHref: url, etag, syncStatus: 'synced' })
               break
             }
             case 'delete': {
-              const eventUrl = `${calendar.url}${eventResourceFilename(change.eventId)}`
+              let pendingEvent: CalendarEvent | undefined
               // Try to get etag from pending change data first (for broken events),
               // then from the live store
               let etag = ''
               if (change.data) {
                 try {
-                  const eventData = JSON.parse(change.data) as CalendarEvent
-                  etag = eventData.etag || ''
+                  pendingEvent = JSON.parse(change.data) as CalendarEvent
+                  etag = pendingEvent.etag || ''
                 } catch {
                   /* ignore parse errors */
                 }
               }
+              const eventUrl =
+                pendingEvent?.resourceHref || `${calendar.url}${eventResourceFilename(change.eventId)}`
               if (!etag) {
                 const eventInStore = useCalendarStore
                   .getState()
@@ -1297,7 +1324,7 @@ export function useCalDAV(): UseCalDAVReturn {
           console.log('[CalDAV] Pushing event to server...')
         }
 
-        const { etag } = await engine.pushEvent(eventWithSequence)
+        const { url, etag } = await engine.pushEvent(eventWithSequence)
 
         if (caldavDebugMode) {
           console.log('[CalDAV] Event pushed successfully!')
@@ -1307,7 +1334,7 @@ export function useCalDAV(): UseCalDAVReturn {
         // sends If-Match against the current server resource. Without this
         // we'd send the empty pre-push etag and strict servers (Radicale,
         // iCloud) would reject the next update.
-        storeUpdateEvent(event.id, { etag, syncStatus: 'synced' })
+        storeUpdateEvent(event.id, { resourceHref: url, etag, syncStatus: 'synced' })
 
         storage.updateAccountLastSync(account.id)
         processPendingChanges()
@@ -1406,7 +1433,21 @@ export function useCalDAV(): UseCalDAVReturn {
           console.log('[CalDAV] Updating event on server...')
         }
 
-        const { etag } = await engine.updateEvent(eventWithSequence, event.etag ?? '')
+        const uid = eventWithSequence.uid || eventWithSequence.id
+        const overrides = !eventWithSequence.recurrenceId
+          ? useCalendarStore
+              .getState()
+              .events.filter(
+                (candidate) =>
+                  candidate.calendarId === calendarId &&
+                  Boolean(candidate.recurrenceId) &&
+                  (candidate.uid === uid || candidate.recurrenceMasterId === eventWithSequence.id)
+              )
+          : []
+        const { url, etag } =
+          overrides.length > 0
+            ? await engine.updateEventGroup([eventWithSequence, ...overrides], event.etag ?? '')
+            : await engine.updateEvent(eventWithSequence, event.etag ?? '')
 
         if (caldavDebugMode) {
           console.log('[CalDAV] Event updated successfully!')
@@ -1416,7 +1457,12 @@ export function useCalDAV(): UseCalDAVReturn {
         // sends If-Match against the current server resource. Without this
         // we'd keep using the pre-update etag and strict servers would
         // reject subsequent edits as stale.
-        storeUpdateEvent(event.id, { etag, syncStatus: 'synced' })
+        storeUpdateEvent(event.id, {
+          resourceHref: url,
+          etag,
+          sequence: eventWithSequence.sequence,
+          syncStatus: 'synced',
+        })
 
         storage.updateAccountLastSync(account.id)
         processPendingChanges()
@@ -1440,6 +1486,78 @@ export function useCalDAV(): UseCalDAVReturn {
       }
     },
     [caldavDebugMode, storeUpdateEvent]
+  )
+
+  const saveRecurrenceOverrideFn = useCallback(
+    async (
+      calendarId: string,
+      master: CalendarEvent,
+      exception: CalendarEvent | null,
+      removedExceptionId?: string
+    ): Promise<void> => {
+      const allCalendars = storage.getAllCalendars()
+      const allAccounts = storage.getAllAccounts()
+      const calendar = allCalendars.find((item) => item.id === calendarId)
+      const account = allAccounts.find((item) => item.id === calendar?.accountId)
+
+      // Local-only calendars have no remote resource to update.
+      if (!calendar) {
+        storeUpdateEvent(master.id, master)
+        if (removedExceptionId) storeDeleteEvent(removedExceptionId)
+        if (exception) storeAddEvent(exception)
+        return
+      }
+      if (!account) throw new Error('Calendar account not found')
+
+      const credential = await getCredentialById(account.credentialId)
+      if (!credential) throw new Error('Credentials not found')
+
+      const uid = master.uid || master.id
+      const existingOverrides = useCalendarStore
+        .getState()
+        .events.filter(
+          (event) =>
+            event.id !== exception?.id &&
+            event.id !== removedExceptionId &&
+            event.calendarId === calendarId &&
+            Boolean(event.recurrenceId) &&
+            (event.uid === uid || event.recurrenceMasterId === master.id)
+        )
+      const masterWithSequence = { ...master, uid, sequence: (master.sequence ?? 0) + 1 }
+      const normalizedException = exception
+        ? {
+            ...exception,
+            uid,
+            recurrenceMasterId: master.id,
+            sequence: masterWithSequence.sequence,
+          }
+        : null
+
+      const client = await createCalDAVClient(account.serverUrl, credential, account.proxyUrl)
+      const engine = new SyncEngine(client, calendarId)
+      const { url, etag } = await engine.updateEventGroup(
+        [masterWithSequence, ...existingOverrides, ...(normalizedException ? [normalizedException] : [])],
+        master.etag ?? ''
+      )
+
+      storeUpdateEvent(master.id, {
+        ...masterWithSequence,
+        resourceHref: url,
+        etag,
+        syncStatus: 'synced',
+      })
+      if (removedExceptionId) storeDeleteEvent(removedExceptionId)
+      if (normalizedException) {
+        storeAddEvent({
+          ...normalizedException,
+          resourceHref: url,
+          etag,
+          syncStatus: 'synced',
+        })
+      }
+      storage.updateAccountLastSync(account.id)
+    },
+    [storeAddEvent, storeDeleteEvent, storeUpdateEvent]
   )
 
   const deleteEventFn = useCallback(
@@ -1496,7 +1614,8 @@ export function useCalDAV(): UseCalDAVReturn {
           console.log('[CalDAV] Deleting event from server...')
         }
 
-        const eventUrl = `${calendar.url}${eventResourceFilename(eventId)}`
+        const eventUrl =
+          effectiveData?.resourceHref || `${calendar.url}${eventResourceFilename(eventId)}`
         // Bug 17 fix: use the event's etag from the store instead of empty string
         await engine.deleteEvent(eventUrl, effectiveData?.etag || '')
 
@@ -1622,12 +1741,12 @@ export function useCalDAV(): UseCalDAVReturn {
 
         if (event.etag) {
           // Event previously existed on server; update it
-          const { etag } = await engine.updateEvent(event, event.etag)
-          storeUpdateEvent(event.id, { etag, syncStatus: 'synced' })
+          const { url, etag } = await engine.updateEvent(event, event.etag)
+          storeUpdateEvent(event.id, { resourceHref: url, etag, syncStatus: 'synced' })
         } else {
           // Event is new; create it
-          const { etag } = await engine.pushEvent({ ...event, sequence: event.sequence ?? 0 })
-          storeUpdateEvent(event.id, { etag, syncStatus: 'synced' })
+          const { url, etag } = await engine.pushEvent({ ...event, sequence: event.sequence ?? 0 })
+          storeUpdateEvent(event.id, { resourceHref: url, etag, syncStatus: 'synced' })
         }
 
         succeeded++
@@ -1766,6 +1885,7 @@ export function useCalDAV(): UseCalDAVReturn {
     syncAll,
     createEvent,
     updateEvent: updateEventFn,
+    saveRecurrenceOverride: saveRecurrenceOverrideFn,
     deleteEvent: deleteEventFn,
     deleteEventByHref,
     retryAllFailedSyncs,

--- a/src/features/caldav/hooks/useCalDAV.ts
+++ b/src/features/caldav/hooks/useCalDAV.ts
@@ -154,7 +154,7 @@ interface UseCalDAVReturn {
     calendarId: string,
     master: CalendarEvent,
     exception: CalendarEvent | null,
-    removedExceptionId?: string
+    removedExceptionIds?: string[]
   ) => Promise<void>
   deleteEvent: (calendarId: string, eventId: string) => Promise<void>
   deleteEventByHref: (calendarId: string, href: string) => Promise<void>
@@ -1493,7 +1493,7 @@ export function useCalDAV(): UseCalDAVReturn {
       calendarId: string,
       master: CalendarEvent,
       exception: CalendarEvent | null,
-      removedExceptionId?: string
+      removedExceptionIds: string[] = []
     ): Promise<void> => {
       const allCalendars = storage.getAllCalendars()
       const allAccounts = storage.getAllAccounts()
@@ -1503,7 +1503,7 @@ export function useCalDAV(): UseCalDAVReturn {
       // Local-only calendars have no remote resource to update.
       if (!calendar) {
         storeUpdateEvent(master.id, master)
-        if (removedExceptionId) storeDeleteEvent(removedExceptionId)
+        for (const eventId of removedExceptionIds) storeDeleteEvent(eventId)
         if (exception) storeAddEvent(exception)
         return
       }
@@ -1518,7 +1518,7 @@ export function useCalDAV(): UseCalDAVReturn {
         .events.filter(
           (event) =>
             event.id !== exception?.id &&
-            event.id !== removedExceptionId &&
+            !removedExceptionIds.includes(event.id) &&
             event.calendarId === calendarId &&
             Boolean(event.recurrenceId) &&
             (event.uid === uid || event.recurrenceMasterId === master.id)
@@ -1546,7 +1546,7 @@ export function useCalDAV(): UseCalDAVReturn {
         etag,
         syncStatus: 'synced',
       })
-      if (removedExceptionId) storeDeleteEvent(removedExceptionId)
+      for (const eventId of removedExceptionIds) storeDeleteEvent(eventId)
       if (normalizedException) {
         storeAddEvent({
           ...normalizedException,

--- a/src/features/caldav/hooks/useCalDAV.ts
+++ b/src/features/caldav/hooks/useCalDAV.ts
@@ -62,6 +62,29 @@ function showToast(message: string): void {
   sonnerToast(message)
 }
 
+function withResourceSiblings(
+  events: CalendarEvent[],
+  allEvents: CalendarEvent[],
+  calendarId: string,
+  resourceHref: string | undefined,
+  excludedIds: string[] = []
+): CalendarEvent[] {
+  if (!resourceHref) return events
+
+  const includedIds = new Set(events.map((event) => event.id))
+  const excluded = new Set(excludedIds)
+  return [
+    ...events,
+    ...allEvents.filter(
+      (event) =>
+        event.calendarId === calendarId &&
+        event.resourceHref === resourceHref &&
+        !includedIds.has(event.id) &&
+        !excluded.has(event.id)
+    ),
+  ]
+}
+
 /**
  * Parse every fetched CalDAV resource into events, pairing each with the
  * resource href it came from, and cache inline attachments in IndexedDB.
@@ -256,10 +279,19 @@ export function useCalDAV(): UseCalDAVReturn {
                       (candidate.uid === uid || candidate.recurrenceMasterId === event.id)
                   )
                 : []
+              const groupedEvents = withResourceSiblings(
+                [event, ...overrides],
+                state.events,
+                change.calendarId,
+                event.resourceHref
+              )
               const { url, etag } =
-                overrides.length > 0
-                  ? await engine.updateEventGroup([event, ...overrides], event.etag || '')
+                groupedEvents.length > 1 && groupedEvents.some((candidate) => !candidate.recurrenceId)
+                  ? await engine.updateEventGroup(groupedEvents, event.etag || '')
                   : await engine.updateEvent(event, event.etag || '')
+              for (const groupedEvent of groupedEvents) {
+                storeUpdateEvent(groupedEvent.id, { resourceHref: url, etag, syncStatus: 'synced' })
+              }
               // Mark as synced in the store
               storeUpdateEvent(change.eventId, { resourceHref: url, etag, syncStatus: 'synced' })
               break
@@ -1444,10 +1476,20 @@ export function useCalDAV(): UseCalDAVReturn {
                   (candidate.uid === uid || candidate.recurrenceMasterId === eventWithSequence.id)
               )
           : []
+        const groupedEvents = withResourceSiblings(
+          [eventWithSequence, ...overrides],
+          useCalendarStore.getState().events,
+          calendarId,
+          event.resourceHref
+        )
         const { url, etag } =
-          overrides.length > 0
-            ? await engine.updateEventGroup([eventWithSequence, ...overrides], event.etag ?? '')
+          groupedEvents.length > 1 && groupedEvents.some((candidate) => !candidate.recurrenceId)
+            ? await engine.updateEventGroup(groupedEvents, event.etag ?? '')
             : await engine.updateEvent(eventWithSequence, event.etag ?? '')
+
+        for (const groupedEvent of groupedEvents) {
+          storeUpdateEvent(groupedEvent.id, { resourceHref: url, etag, syncStatus: 'synced' })
+        }
 
         if (caldavDebugMode) {
           console.log('[CalDAV] Event updated successfully!')
@@ -1535,11 +1577,18 @@ export function useCalDAV(): UseCalDAVReturn {
 
       const client = await createCalDAVClient(account.serverUrl, credential, account.proxyUrl)
       const engine = new SyncEngine(client, calendarId)
-      const { url, etag } = await engine.updateEventGroup(
+      const groupedEvents = withResourceSiblings(
         [masterWithSequence, ...existingOverrides, ...(normalizedException ? [normalizedException] : [])],
-        master.etag ?? ''
+        useCalendarStore.getState().events,
+        calendarId,
+        master.resourceHref,
+        removedExceptionIds
       )
+      const { url, etag } = await engine.updateEventGroup(groupedEvents, master.etag ?? '')
 
+      for (const groupedEvent of groupedEvents) {
+        storeUpdateEvent(groupedEvent.id, { resourceHref: url, etag, syncStatus: 'synced' })
+      }
       storeUpdateEvent(master.id, {
         ...masterWithSequence,
         resourceHref: url,

--- a/src/features/caldav/sync/__tests__/detectUidCollisions.test.ts
+++ b/src/features/caldav/sync/__tests__/detectUidCollisions.test.ts
@@ -56,6 +56,25 @@ describe('detectUidCollisions', () => {
     expect(reversed.skip.has(b)).toBe(true)
   })
 
+  it('skips overrides belonging to the losing duplicate resource', () => {
+    const keptMaster = entry(makeEvent({ id: 'shared', uid: 'shared' }), '/cal/a.ics')
+    const losingMaster = entry(makeEvent({ id: 'shared', uid: 'shared' }), '/cal/b.ics')
+    const losingOverride = entry(
+      makeEvent({
+        id: 'shared-2024-04-02T00:00:00Z',
+        uid: 'shared',
+        recurrenceId: '2024-04-02T00:00:00Z',
+      }),
+      '/cal/b.ics'
+    )
+
+    const { skip } = detectUidCollisions([keptMaster, losingMaster, losingOverride])
+
+    expect(skip.has(keptMaster)).toBe(false)
+    expect(skip.has(losingMaster)).toBe(true)
+    expect(skip.has(losingOverride)).toBe(true)
+  })
+
   it('does not flag a recurring master plus a RECURRENCE-ID override sharing a UID', () => {
     const master = entry(
       makeEvent({ id: 'birthday', rruleString: 'FREQ=YEARLY' }),

--- a/src/features/caldav/sync/__tests__/syncEngine.test.ts
+++ b/src/features/caldav/sync/__tests__/syncEngine.test.ts
@@ -158,4 +158,45 @@ describe('SyncEngine', () => {
       '"etag"'
     )
   })
+
+  it('updates a fetched event at its original CalDAV resource URL', async () => {
+    const event = makeEvent({
+      resourceHref: 'https://caldav.example.com/calendars/test/default/server-generated.ics',
+    })
+
+    await engine.updateEvent(event, '"etag"')
+
+    expect(mockClient.updateEvent).toHaveBeenCalledWith(
+      'https://caldav.example.com/calendars/test/default/',
+      event.resourceHref,
+      expect.any(String),
+      '"etag"'
+    )
+  })
+
+  it('updates a recurrence master and override in the same resource', async () => {
+    const master = makeEvent({
+      uid: 'series-uid',
+      resourceHref: 'https://caldav.example.com/calendars/test/default/series.ics',
+      rruleString: 'FREQ=WEEKLY',
+    })
+    const exception = makeEvent({
+      id: 'series-uid-2024-03-22T14:00:00.000Z',
+      uid: 'series-uid',
+      recurrenceId: '2024-03-22T14:00:00.000Z',
+      recurrenceMasterId: master.id,
+    })
+
+    await engine.updateEventGroup([master, exception], '"etag"')
+
+    expect(mockClient.updateEvent).toHaveBeenCalledWith(
+      'https://caldav.example.com/calendars/test/default/',
+      master.resourceHref,
+      expect.stringContaining('RECURRENCE-ID:20240322T140000Z'),
+      '"etag"'
+    )
+    const body = vi.mocked(mockClient.updateEvent!).mock.calls[0][2]
+    expect(body.match(/BEGIN:VEVENT/g)).toHaveLength(2)
+    expect(body.match(/UID:series-uid/g)).toHaveLength(2)
+  })
 })

--- a/src/features/caldav/sync/detectUidCollisions.ts
+++ b/src/features/caldav/sync/detectUidCollisions.ts
@@ -66,8 +66,9 @@ export function detectUidCollisions(items: ParsedWithHref[]): UidCollisionResult
       kept: entry === kept,
     }))
 
-    for (const entry of sorted) {
-      if (entry !== kept) skip.add(entry)
+    for (const entry of items) {
+      const entryUid = entry.event.uid || entry.event.id
+      if (entryUid === uid && entry.href !== kept.href) skip.add(entry)
     }
 
     issues.push({

--- a/src/features/caldav/sync/syncEngine.ts
+++ b/src/features/caldav/sync/syncEngine.ts
@@ -1,7 +1,7 @@
 import type { CalendarEvent } from '@/types'
 import type { SyncResult, ConflictResolution } from '../types'
 import { CalDAVClient } from '../client/CalDAVClient'
-import { eventToICAL, parseICALData, taskToICAL, journalToICAL } from '../adapter/iCalendarAdapter'
+import { eventToICAL, eventsToICAL, parseICALData, taskToICAL, journalToICAL } from '../adapter/iCalendarAdapter'
 import { isUUID } from '@/lib/uuid'
 import * as storage from './accountStorage'
 import { getAttachments, putAttachments } from '@/lib/attachmentStore'
@@ -82,6 +82,7 @@ export class SyncEngine {
         parsedEvents.push({
           ...event,
           etag: serverEvent.etag,
+          resourceHref: serverEvent.url,
         })
         if (event.categories) {
           for (const cat of event.categories) {
@@ -173,9 +174,21 @@ export class SyncEngine {
     } else {
       iCalString = eventToICAL(enriched)
     }
-    const eventUrl = `${calendar.url}${eventResourceFilename(event.id)}`
+    const eventUrl = event.resourceHref || `${calendar.url}${eventResourceFilename(event.id)}`
 
     return this.client.updateEvent(calendar.url, eventUrl, iCalString, etag)
+  }
+
+  async updateEventGroup(events: CalendarEvent[], etag: string): Promise<{ url: string; etag: string }> {
+    const calendar = storage.getAllCalendars().find((c) => c.id === this.calendarId)
+    const master = events.find((event) => !event.recurrenceId)
+    if (!calendar || !master) {
+      throw new Error(`Calendar or recurrence master not found: ${this.calendarId}`)
+    }
+
+    const enriched = await Promise.all(events.map((event) => withInlineAttachments(event)))
+    const eventUrl = master.resourceHref || `${calendar.url}${eventResourceFilename(master.id)}`
+    return this.client.updateEvent(calendar.url, eventUrl, eventsToICAL(enriched), etag)
   }
 
   async deleteEvent(eventUrl: string, etag: string): Promise<void> {

--- a/src/features/calendar/__tests__/EventModal.test.tsx
+++ b/src/features/calendar/__tests__/EventModal.test.tsx
@@ -512,7 +512,7 @@ describe('EventModal', () => {
         // Master title unchanged; the occurrence is excluded from expansion.
         const master = events.find((e) => e.id === 'series-master')
         expect(master?.title).toBe('Original Title')
-        expect(master?.excludedDates).toContain('2024-03-15')
+        expect(master?.excludedDates ?? []).not.toContain('2024-03-15T10:00:00.000Z')
         // Exception event lands on the clicked date (2024-03-15), not 2024-03-01.
         const exception = events.find((e) => e.title === 'Just This One')
         expect(exception).toBeDefined()

--- a/src/features/calendar/__tests__/EventModal.test.tsx
+++ b/src/features/calendar/__tests__/EventModal.test.tsx
@@ -8,6 +8,7 @@ describe('EventModal', () => {
     const store = useCalendarStore.getState()
     store.events.forEach((e) => store.deleteEvent(e.id))
     store.calendars.forEach((c) => store.deleteCalendar(c.id))
+    store.categories.forEach((c) => store.deleteCategory(c.id))
     store.addCalendar({
       id: 'default',
       name: 'Default Calendar',
@@ -518,6 +519,51 @@ describe('EventModal', () => {
         expect(exception).toBeDefined()
         expect(exception?.start).toContain('2024-03-15')
         expect(exception?.recurrence).toBeUndefined()
+      })
+    })
+
+    it('keeps the selected category on a single-occurrence exception', async () => {
+      const store = useCalendarStore.getState()
+      store.addCategory({ id: 'work-category', name: 'Work', color: '#4285F4' })
+      seedSeries()
+      render(<EventModal />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Work' }))
+      fireEvent.click(screen.getByRole('button', { name: /save/i }))
+      fireEvent.click(screen.getByRole('button', { name: /this event only/i }))
+
+      await waitFor(() => {
+        const exception = useCalendarStore
+          .getState()
+          .events.find((event) => event.recurrenceId === '2024-03-15T10:00:00.000Z')
+        expect(exception?.categories).toEqual(['Work'])
+      })
+    })
+
+    it('re-edits an existing exception without changing the recurrence master', async () => {
+      const store = useCalendarStore.getState()
+      store.addCategory({ id: 'work-category', name: 'Work', color: '#4285F4' })
+      store.addEvent({
+        id: 'series-master', uid: 'series-master', calendarId: 'default', title: 'Master title',
+        start: '2024-03-01T10:00:00', end: '2024-03-01T11:00:00', isAllDay: false,
+        recurrence: { frequency: 'weekly', interval: 1 },
+      })
+      store.addEvent({
+        id: 'series-master-2024-03-15T10:00:00.000Z', uid: 'series-master', calendarId: 'default',
+        title: 'Edited occurrence', start: '2024-03-15T10:00:00.000Z',
+        end: '2024-03-15T11:00:00.000Z', isAllDay: false,
+        recurrenceId: '2024-03-15T10:00:00.000Z', recurrenceMasterId: 'series-master',
+      })
+      store.openModal(undefined, undefined, 'series-master-2024-03-15T10:00:00.000Z')
+      render(<EventModal />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Work' }))
+      fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+      await waitFor(() => {
+        const events = useCalendarStore.getState().events
+        expect(events.find((event) => event.id === 'series-master')?.categories).toEqual([])
+        expect(events.find((event) => event.recurrenceId)?.categories).toEqual(['Work'])
       })
     })
   })

--- a/src/features/calendar/__tests__/EventModal.test.tsx
+++ b/src/features/calendar/__tests__/EventModal.test.tsx
@@ -560,6 +560,7 @@ describe('EventModal', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Work' }))
       fireEvent.click(screen.getByRole('button', { name: /save/i }))
 
+      expect(screen.queryByText('Edit recurring event')).not.toBeInTheDocument()
       await waitFor(() => {
         const events = useCalendarStore.getState().events
         expect(events.find((event) => event.id === 'series-master')?.categories).toEqual([])

--- a/src/features/calendar/__tests__/EventPreviewPopup.test.tsx
+++ b/src/features/calendar/__tests__/EventPreviewPopup.test.tsx
@@ -397,6 +397,39 @@ describe('EventPreviewPopup', () => {
         expect(exception?.recurrence).toBeUndefined()
       })
     })
+
+    it('re-edits a detached occurrence without showing recurrence options', async () => {
+      const master = seedSeries()
+      const exception: CalendarEvent = {
+        ...master,
+        id: instanceId,
+        title: 'Detached occurrence',
+        start: '2024-03-15T10:00:00.000Z',
+        end: '2024-03-15T11:00:00.000Z',
+        recurrence: undefined,
+        recurrenceId: '2024-03-15T10:00:00.000Z',
+        recurrenceMasterId: master.id,
+      }
+      useCalendarStore.getState().addEvent(exception)
+      render(
+        <EventPreviewPopup event={exception} position={mockPosition} clickedEventId={instanceId} />
+      )
+
+      fireEvent.click(screen.getByText('Detached occurrence'))
+      fireEvent.change(screen.getByDisplayValue('Detached occurrence'), {
+        target: { value: 'Detached occurrence updated' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+      expect(screen.queryByText('Edit recurring event')).not.toBeInTheDocument()
+      await waitFor(() => {
+        const events = useCalendarStore.getState().events
+        expect(events.find((event) => event.id === master.id)?.title).toBe('Weekly Sync')
+        expect(events.find((event) => event.id === instanceId)?.title).toBe(
+          'Detached occurrence updated'
+        )
+      })
+    })
   })
 
   describe('date field changes preserve start<=end (issue #44)', () => {

--- a/src/features/calendar/__tests__/EventPreviewPopup.test.tsx
+++ b/src/features/calendar/__tests__/EventPreviewPopup.test.tsx
@@ -389,7 +389,7 @@ describe('EventPreviewPopup', () => {
         const events = useCalendarStore.getState().events
         const original = events.find((e) => e.id === 'series')
         expect(original?.title).toBe('Weekly Sync')
-        expect(original?.excludedDates).toContain('2024-03-15')
+        expect(original?.excludedDates ?? []).not.toContain('2024-03-15T10:00:00.000Z')
         // Exception lands on the clicked occurrence date, not the master's start.
         const exception = events.find((e) => e.id === instanceId)
         expect(exception?.title).toBe('Just This One')

--- a/src/features/calendar/components/DeleteDialog.tsx
+++ b/src/features/calendar/components/DeleteDialog.tsx
@@ -57,6 +57,9 @@ export function DeleteDialog({
             <button type="button" className={styles.deleteButton} onClick={() => onConfirm('this')}>
               This event only
             </button>
+            <button type="button" className={styles.deleteButton} onClick={() => onConfirm('future')}>
+              This and following events
+            </button>
             <button type="button" className={styles.cancelButton} onClick={requestClose}>
               Cancel
             </button>

--- a/src/features/calendar/components/EventCard.tsx
+++ b/src/features/calendar/components/EventCard.tsx
@@ -19,6 +19,7 @@ import { useDragModifierStore } from '@/store/dragModifierStore'
 import { safeCalDAVUpdate } from '@/lib/caldavHelpers'
 import { deleteEventWithUndo } from '@/lib/deleteWithUndo'
 import { showToast } from '@/lib/toast'
+import { buildMasterTruncation, getFutureOverrideIds, isFirstOccurrence } from '@/lib/recurrenceSplit'
 
 import { extractOriginalEventId, hasDueTime, formatTravelDuration } from '@/lib/events'
 import { hapticIfEnabled } from '@/lib/haptics'
@@ -610,8 +611,9 @@ export const EventCard = React.memo(function EventCard({
             isOpen={showDeleteDialog}
             onClose={() => setShowDeleteDialog(false)}
             onConfirm={async (mode) => {
-              if (mode === 'this' && originalEventId) {
-                const masterEvent = useCalendarStore.getState().events.find((e) => e.id === originalEventId)
+              const recurringMasterId = originalEventId || event.id
+              if (mode === 'this') {
+                const masterEvent = useCalendarStore.getState().events.find((e) => e.id === recurringMasterId)
                 if (masterEvent) {
                   const occurrenceStart = event.recurrenceId || event.start
                   const dateStr = occurrenceStart.split('T')[0]
@@ -626,12 +628,47 @@ export const EventCard = React.memo(function EventCard({
                         masterEvent.calendarId,
                         { ...masterEvent, excludedDates: updatedExcludedDates },
                         null,
-                        event.recurrenceId ? event.id : undefined
+                        event.recurrenceId ? [event.id] : []
                       )
                     } catch {
                       showToast('Failed to delete this occurrence. The event was kept.')
                       return
                     }
+                  }
+                }
+              } else if (mode === 'future') {
+                const storedEvents = useCalendarStore.getState().events
+                const masterEvent = storedEvents.find((candidate) => candidate.id === recurringMasterId)
+                const occurrenceStart = event.recurrenceId || event.start
+                const occurrenceDate = occurrenceStart.split('T')[0]
+                if (masterEvent && occurrenceDate) {
+                  if (isFirstOccurrence(masterEvent, occurrenceStart)) {
+                    deleteEventWithUndo({
+                      event: masterEvent,
+                      deleteEvent,
+                      addEvent,
+                      createCalDAVEvent,
+                      deleteCalDAVEvent,
+                    })
+                    setShowDeleteDialog(false)
+                    return
+                  }
+                  const truncation = buildMasterTruncation(masterEvent, occurrenceStart)
+                  const removedOverrideIds = getFutureOverrideIds(
+                    storedEvents,
+                    masterEvent,
+                    occurrenceStart
+                  )
+                  try {
+                    await saveRecurrenceOverride(
+                      masterEvent.calendarId,
+                      { ...masterEvent, ...truncation },
+                      null,
+                      removedOverrideIds
+                    )
+                  } catch {
+                    showToast('Failed to delete this and following events. The series was kept.')
+                    return
                   }
                 }
               } else if (originalEventId) {

--- a/src/features/calendar/components/EventCard.tsx
+++ b/src/features/calendar/components/EventCard.tsx
@@ -75,7 +75,12 @@ export const EventCard = React.memo(function EventCard({
   const addEvent = useCalendarStore((state) => state.addEvent)
   const duplicateEvent = useCalendarStore((state) => state.duplicateEvent)
   const timeFormat = useSettingsStore((state) => state.timeFormat)
-  const { deleteEvent: deleteCalDAVEvent, updateEvent: updateCalDAVEvent, createEvent: createCalDAVEvent } = useCalDAV()
+  const {
+    deleteEvent: deleteCalDAVEvent,
+    updateEvent: updateCalDAVEvent,
+    createEvent: createCalDAVEvent,
+    saveRecurrenceOverride,
+  } = useCalDAV()
   // Cross-fragment hover: a multi-day event is rendered as separate cards per
   // grid cell. Share one hover highlight by tracking the hovered id in a store.
   // Subscribe to a boolean so only the previously- and newly-hovered cards
@@ -608,21 +613,24 @@ export const EventCard = React.memo(function EventCard({
               if (mode === 'this' && originalEventId) {
                 const masterEvent = useCalendarStore.getState().events.find((e) => e.id === originalEventId)
                 if (masterEvent) {
-                  const dateMatch = event.id.match(/(\d{4}-\d{2}-\d{2})/)
-                  const dateStr = dateMatch ? dateMatch[1] : null
+                  const occurrenceStart = event.recurrenceId || event.start
+                  const dateStr = occurrenceStart.split('T')[0]
                   if (dateStr) {
+                    const exclusionValue = masterEvent.isAllDay ? dateStr : occurrenceStart
                     const excludedDates = masterEvent.excludedDates || []
-                    if (!excludedDates.includes(dateStr)) {
-                      const updatedExcludedDates = [...excludedDates, dateStr]
-                      updateEvent(originalEventId, {
-                        excludedDates: updatedExcludedDates,
-                      })
-                      await safeCalDAVUpdate(
-                        updateCalDAVEvent,
+                    const updatedExcludedDates = excludedDates.includes(exclusionValue)
+                      ? excludedDates
+                      : [...excludedDates, exclusionValue]
+                    try {
+                      await saveRecurrenceOverride(
                         masterEvent.calendarId,
                         { ...masterEvent, excludedDates: updatedExcludedDates },
-                        { excludedDates: updatedExcludedDates }
+                        null,
+                        event.recurrenceId ? event.id : undefined
                       )
+                    } catch {
+                      showToast('Failed to delete this occurrence. The event was kept.')
+                      return
                     }
                   }
                 }

--- a/src/features/calendar/components/EventModal.tsx
+++ b/src/features/calendar/components/EventModal.tsx
@@ -63,6 +63,7 @@ export function EventModal(): JSX.Element | null {
   const {
     createEvent: createCalDAVEvent,
     updateEvent: updateCalDAVEvent,
+    saveRecurrenceOverride,
     deleteEvent: deleteCalDAVEvent,
   } = useCalDAV()
 
@@ -738,10 +739,12 @@ export function EventModal(): JSX.Element | null {
         // occurrence's date, preserving the event's time-of-day and duration
         // (including any edits the user made in the form). Falls back to the form
         // date for non-instance ids (plain master edits).
+        const selectedStoredEvent = events.find((event) => event.id === selectedEventId)
+        const selectedRecurrenceId = selectedStoredEvent?.recurrenceId
         const occInstanceMatch = selectedEventId.match(
           /-(\d{4}-\d{2}-\d{2})T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
         )
-        const occDateStr = occInstanceMatch ? occInstanceMatch[1] : startDate
+        const occDateStr = selectedRecurrenceId?.split('T')[0] || (occInstanceMatch ? occInstanceMatch[1] : startDate)
         const durationMs = new Date(endDateTime).getTime() - new Date(startDateTime).getTime()
         const occStartDateTime = isAllDay
           ? `${occDateStr}T00:00:00`
@@ -769,7 +772,7 @@ export function EventModal(): JSX.Element | null {
           const isoDateMatch = selectedEventId.match(
             /(.+)-(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)$/
           )
-          const originalOccurrenceDate = isoDateMatch ? isoDateMatch[2] : null
+          const originalOccurrenceDate = selectedRecurrenceId || (isoDateMatch ? isoDateMatch[2] : null)
           if (!originalOccurrenceDate) {
             showToast('Invalid event data. Cannot edit single occurrence.')
             return
@@ -777,6 +780,7 @@ export function EventModal(): JSX.Element | null {
 
           const exceptionEvent: CalendarEvent = {
             id: `${originalEventId}-${originalOccurrenceDate}`,
+            uid: masterEvent.uid || masterEvent.id,
             calendarId: masterEvent.calendarId,
             title,
             description: description || undefined,
@@ -787,6 +791,7 @@ export function EventModal(): JSX.Element | null {
             recurrence: undefined,
             rruleString: undefined,
             recurrenceId: originalOccurrenceDate,
+            recurrenceMasterId: originalEventId,
             travelDuration,
             reminders,
             transparency,
@@ -795,31 +800,25 @@ export function EventModal(): JSX.Element | null {
             attachments: attachments.length > 0 ? attachments : undefined,
           }
 
-          addEvent(exceptionEvent)
-          // Sync IndexedDB for exception event
-          if (attachments.length > 0) {
-            putAttachments(exceptionEvent.id, attachments).catch(() => {})
+          const occurrenceDate = originalOccurrenceDate.split('T')[0]
+          const masterWithoutLegacyExdate = {
+            ...masterEvent,
+            excludedDates: masterEvent.excludedDates?.filter(
+              (date) => date.split('T')[0] !== occurrenceDate
+            ),
           }
           try {
-            await createCalDAVEvent(masterEvent.calendarId, exceptionEvent)
-          } catch {
-            showToast('Failed to sync event with CalDAV server. It will be retried.')
-          }
-
-          // Add EXDATE to master so rrule expansion skips this date and only
-          // the exception event is shown.  Without this the master would still
-          // generate an occurrence on that date, creating a visible duplicate.
-          const occurrenceDate = originalOccurrenceDate.split('T')[0]
-          const masterExcludedDates = masterEvent.excludedDates || []
-          if (!masterExcludedDates.includes(occurrenceDate)) {
-            const updatedExcludedDates = [...masterExcludedDates, occurrenceDate]
-            updateEvent(originalEventId, { excludedDates: updatedExcludedDates })
-            await safeCalDAVUpdate(
-              updateCalDAVEvent,
+            await saveRecurrenceOverride(
               masterEvent.calendarId,
-              { ...masterEvent, excludedDates: updatedExcludedDates },
-              { excludedDates: updatedExcludedDates }
-            ).catch(() => {})
+              masterWithoutLegacyExdate,
+              exceptionEvent
+            )
+          } catch {
+            showToast('Failed to update this occurrence. The original event was kept.')
+            return
+          }
+          if (attachments.length > 0) {
+            putAttachments(exceptionEvent.id, attachments).catch(() => {})
           }
         } else if (mode === 'future' && originalEventId) {
           // "This and following events": split the series at the current
@@ -835,7 +834,7 @@ export function EventModal(): JSX.Element | null {
           const isoDateMatch = selectedEventId.match(
             /(.+)-(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)$/
           )
-          const originalOccurrenceDate = isoDateMatch ? isoDateMatch[2] : null
+          const originalOccurrenceDate = selectedRecurrenceId || (isoDateMatch ? isoDateMatch[2] : null)
           if (!originalOccurrenceDate) {
             showToast('Invalid event data. Cannot split series.')
             return
@@ -1096,16 +1095,22 @@ export function EventModal(): JSX.Element | null {
       const occurrenceDate = occurrenceStartISO.split('T')[0]
       const masterEvent = events.find((e) => e.id === originalEventId)
       if (masterEvent) {
+        const selectedException = events.find((event) => event.id === selectedEventId)
+        const exclusionValue = masterEvent.isAllDay ? occurrenceDate : occurrenceStartISO
         const excludedDates = masterEvent.excludedDates || []
-        if (!excludedDates.includes(occurrenceDate)) {
-          const updatedExcludedDates = [...excludedDates, occurrenceDate]
-          updateEvent(originalEventId, { excludedDates: updatedExcludedDates })
-          await safeCalDAVUpdate(
-            updateCalDAVEvent,
+        const updatedExcludedDates = excludedDates.includes(exclusionValue)
+          ? excludedDates
+          : [...excludedDates, exclusionValue]
+        try {
+          await saveRecurrenceOverride(
             calendarId,
             { ...masterEvent, excludedDates: updatedExcludedDates },
-            { excludedDates: updatedExcludedDates }
+            null,
+            selectedException?.recurrenceId ? selectedException.id : undefined
           )
+        } catch {
+          showToast('Failed to delete this occurrence. The event was kept.')
+          return
         }
       }
     } else {

--- a/src/features/calendar/components/EventModal.tsx
+++ b/src/features/calendar/components/EventModal.tsx
@@ -9,7 +9,7 @@ import { showToast } from '@/lib/toast'
 import { safeCalDAVUpdate } from '@/lib/caldavHelpers'
 import { deleteEventWithUndo } from '@/lib/deleteWithUndo'
 import { buildRRuleString } from '@/lib/recurrence'
-import { buildMasterTruncation } from '@/lib/recurrenceSplit'
+import { buildMasterTruncation, getFutureOverrideIds, isFirstOccurrence } from '@/lib/recurrenceSplit'
 import type { CalendarEvent, CalendarAttachment, RecurrenceRule, TaskPriority, Reminder } from '@/types'
 import { putAttachments, getAttachments, deleteAttachments } from '@/lib/attachmentStore'
 import { TaskFormFields } from './TaskFormFields'
@@ -840,14 +840,12 @@ export function EventModal(): JSX.Element | null {
             return
           }
 
-          const occurrenceDateStr = originalOccurrenceDate.split('T')[0]
-          // Update master: end its recurrence the day before the split and add an
-          // EXDATE for the split date (shared with the preview popup's split path).
+          // Update master so it ends immediately before the split occurrence.
           const {
             excludedDates: updatedExcludedDates,
             recurrence: masterRecurrence,
             rruleString: masterRruleString,
-          } = buildMasterTruncation(masterEvent, occurrenceDateStr)
+          } = buildMasterTruncation(masterEvent, originalOccurrenceDate)
 
           updateEvent(originalEventId, {
             excludedDates: updatedExcludedDates,
@@ -1088,14 +1086,20 @@ export function EventModal(): JSX.Element | null {
   }
 
   const performDelete = async (mode: RecurrenceEditMode): Promise<void> => {
-    if (mode === 'this' && originalEventId) {
+    const recurringMasterId = originalEventId || selectedEventId
+    if (mode === 'this' && recurringMasterId) {
       // Add the occurrence's date to excludedDates on the master - do not delete the series
       if (!selectedEventId) return
-      const occurrenceStartISO = selectedEventId.slice(originalEventId.length + 1)
+      const selectedException = events.find((event) => event.id === selectedEventId)
+      const occurrenceStartISO =
+        selectedException?.recurrenceId ||
+        (originalEventId
+          ? selectedEventId.slice(originalEventId.length + 1)
+          : selectedException?.start)
+      if (!occurrenceStartISO) return
       const occurrenceDate = occurrenceStartISO.split('T')[0]
-      const masterEvent = events.find((e) => e.id === originalEventId)
+      const masterEvent = events.find((e) => e.id === recurringMasterId)
       if (masterEvent) {
-        const selectedException = events.find((event) => event.id === selectedEventId)
         const exclusionValue = masterEvent.isAllDay ? occurrenceDate : occurrenceStartISO
         const excludedDates = masterEvent.excludedDates || []
         const updatedExcludedDates = excludedDates.includes(exclusionValue)
@@ -1106,10 +1110,47 @@ export function EventModal(): JSX.Element | null {
             calendarId,
             { ...masterEvent, excludedDates: updatedExcludedDates },
             null,
-            selectedException?.recurrenceId ? selectedException.id : undefined
+            selectedException?.recurrenceId ? [selectedException.id] : []
           )
         } catch {
           showToast('Failed to delete this occurrence. The event was kept.')
+          return
+        }
+      }
+    } else if (mode === 'future' && recurringMasterId && selectedEventId) {
+      const masterEvent = events.find((event) => event.id === recurringMasterId)
+      const selectedException = events.find((event) => event.id === selectedEventId)
+      const occurrenceStart =
+        selectedException?.recurrenceId ||
+        (originalEventId
+          ? selectedEventId.slice(originalEventId.length + 1)
+          : selectedException?.start)
+      if (!occurrenceStart) return
+      const occurrenceDate = occurrenceStart.split('T')[0]
+      if (masterEvent && occurrenceDate) {
+        if (isFirstOccurrence(masterEvent, occurrenceStart)) {
+          deleteEventWithUndo({
+            event: masterEvent,
+            deleteEvent,
+            addEvent,
+            createCalDAVEvent,
+            deleteCalDAVEvent,
+          })
+          setShowDeleteDialog(false)
+          closeModal()
+          return
+        }
+        const truncation = buildMasterTruncation(masterEvent, occurrenceStart)
+        const removedOverrideIds = getFutureOverrideIds(events, masterEvent, occurrenceStart)
+        try {
+          await saveRecurrenceOverride(
+            masterEvent.calendarId,
+            { ...masterEvent, ...truncation },
+            null,
+            removedOverrideIds
+          )
+        } catch {
+          showToast('Failed to delete this and following events. The series was kept.')
           return
         }
       }

--- a/src/features/calendar/components/EventModal.tsx
+++ b/src/features/calendar/components/EventModal.tsx
@@ -454,7 +454,7 @@ export function EventModal(): JSX.Element | null {
   // isCalendarReadOnly() in calendarStore.ts (store actions themselves stay
   // unguarded since sync writes to these calendars legitimately).
   const isCurrentCalendarReadOnly = calendars.find((c) => c.id === calendarId)?.readOnly === true
-  const isRecurringEvent = initialState.recurring || initialState.isRecurringInstance
+  const isRecurringEvent = initialState.recurring
   const showSuggestions = !isEditing && titleSuggestions.length > 0
   const originalEventId = initialState.originalEventId
   const existingEventForMode = selectedEventId
@@ -1090,7 +1090,7 @@ export function EventModal(): JSX.Element | null {
       return
     }
 
-    performDelete('all')
+    performDelete(existingEventForMode?.recurrenceId ? 'this' : 'all')
   }
 
   const performDelete = async (mode: RecurrenceEditMode): Promise<void> => {

--- a/src/features/calendar/components/EventModal.tsx
+++ b/src/features/calendar/components/EventModal.tsx
@@ -454,7 +454,7 @@ export function EventModal(): JSX.Element | null {
   // isCalendarReadOnly() in calendarStore.ts (store actions themselves stay
   // unguarded since sync writes to these calendars legitimately).
   const isCurrentCalendarReadOnly = calendars.find((c) => c.id === calendarId)?.readOnly === true
-  const isRecurringEvent = initialState.recurring
+  const isRecurringEvent = initialState.recurring || initialState.isRecurringInstance
   const showSuggestions = !isEditing && titleSuggestions.length > 0
   const originalEventId = initialState.originalEventId
   const existingEventForMode = selectedEventId
@@ -653,6 +653,12 @@ export function EventModal(): JSX.Element | null {
       return
     }
 
+    // Stored exceptions are already detached, so save them back as the same occurrence.
+    if (isEditing && initialState.isRecurringInstance && existingEventForMode?.recurrenceId && hasChanges) {
+      saveEvent('this')
+      return
+    }
+
     if (isEditing && isRecurringEvent && hasChanges) {
       setShowRecurrenceDialog(true)
       return
@@ -779,6 +785,7 @@ export function EventModal(): JSX.Element | null {
           }
 
           const exceptionEvent: CalendarEvent = {
+            ...(selectedStoredEvent?.recurrenceId ? selectedStoredEvent : masterEvent),
             id: `${originalEventId}-${originalOccurrenceDate}`,
             uid: masterEvent.uid || masterEvent.id,
             calendarId: masterEvent.calendarId,
@@ -792,6 +799,7 @@ export function EventModal(): JSX.Element | null {
             rruleString: undefined,
             recurrenceId: originalOccurrenceDate,
             recurrenceMasterId: originalEventId,
+            categories: selectedCategories,
             travelDuration,
             reminders,
             transparency,
@@ -1400,6 +1408,7 @@ export function EventModal(): JSX.Element | null {
                     <button
                       key={cat.id}
                       type="button"
+                      aria-pressed={selectedCategories.includes(cat.name)}
                       className={`${styles.categoryChip} ${
                         selectedCategories.includes(cat.name) ? styles.categoryChipSelected : ''
                       }`}

--- a/src/features/calendar/components/EventPreviewPopup.tsx
+++ b/src/features/calendar/components/EventPreviewPopup.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { format, parseISO, isSameDay } from 'date-fns'
 import { v4 as uuidv4 } from 'uuid'
 import { formatTime, daysBetween, addDays } from '@/lib/datetime'
-import { buildMasterTruncation } from '@/lib/recurrenceSplit'
+import { buildMasterTruncation, getFutureOverrideIds, isFirstOccurrence } from '@/lib/recurrenceSplit'
 import { showToast } from '@/lib/toast'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useReducedMotion } from '@/hooks/useReducedMotion'
@@ -302,7 +302,7 @@ export function EventPreviewPopup({
       const newSeriesRrule = masterEvent.rruleString
       const { excludedDates, recurrence, rruleString } = buildMasterTruncation(
         masterEvent,
-        occurrenceDateStr
+        occurrenceStartISO
       )
       updateEvent(masterEvent.id, { excludedDates, recurrence, rruleString })
       safeCalDAVUpdate(
@@ -447,14 +447,17 @@ export function EventPreviewPopup({
   }
 
   const performDelete = async (mode: 'all' | 'this' | 'future'): Promise<void> => {
-    if (mode === 'this' && originalEventId) {
+    const recurringMasterId = originalEventId || event.id
+    if (mode === 'this') {
       // For 'this' occurrence: exclude the date from the master event
-      const occurrenceStartISO = clickedEventId.slice(originalEventId.length + 1)
-      const occurrenceDate = occurrenceStartISO.split('T')[0]
       const storedEvents = useCalendarStore.getState().events
-      const masterEvent = storedEvents.find((e) => e.id === originalEventId)
+      const selectedException = storedEvents.find((candidate) => candidate.id === clickedEventId)
+      const occurrenceStartISO =
+        selectedException?.recurrenceId ||
+        (originalEventId ? clickedEventId.slice(originalEventId.length + 1) : event.start)
+      const occurrenceDate = occurrenceStartISO.split('T')[0]
+      const masterEvent = storedEvents.find((e) => e.id === recurringMasterId)
       if (masterEvent) {
-        const selectedException = storedEvents.find((candidate) => candidate.id === clickedEventId)
         const exclusionValue = masterEvent.isAllDay ? occurrenceDate : occurrenceStartISO
         const excludedDates = masterEvent.excludedDates || []
         const updatedExcludedDates = excludedDates.includes(exclusionValue)
@@ -465,10 +468,42 @@ export function EventPreviewPopup({
             masterEvent.calendarId,
             { ...masterEvent, excludedDates: updatedExcludedDates },
             null,
-            selectedException?.recurrenceId ? selectedException.id : undefined
+            selectedException?.recurrenceId ? [selectedException.id] : []
           )
         } catch {
           showToast('Failed to delete this occurrence. The event was kept.')
+          return
+        }
+      }
+    } else if (mode === 'future') {
+      const storedEvents = useCalendarStore.getState().events
+      const masterEvent = storedEvents.find((candidate) => candidate.id === recurringMasterId)
+      const selectedException = storedEvents.find((candidate) => candidate.id === clickedEventId)
+      const occurrenceStart =
+        selectedException?.recurrenceId ||
+        (originalEventId ? clickedEventId.slice(originalEventId.length + 1) : event.start)
+      const occurrenceDate = occurrenceStart.split('T')[0]
+      if (masterEvent && occurrenceDate) {
+        if (isFirstOccurrence(masterEvent, occurrenceStart)) {
+          if (masterEvent.calendarId !== 'default') {
+            await safeCalDAVDelete(deleteCalDAVEvent, masterEvent.calendarId, masterEvent.id)
+          }
+          deleteEvent(masterEvent.id)
+          closePreview()
+          setShowDeleteDialog(false)
+          return
+        }
+        const truncation = buildMasterTruncation(masterEvent, occurrenceStart)
+        const removedOverrideIds = getFutureOverrideIds(storedEvents, masterEvent, occurrenceStart)
+        try {
+          await saveRecurrenceOverride(
+            masterEvent.calendarId,
+            { ...masterEvent, ...truncation },
+            null,
+            removedOverrideIds
+          )
+        } catch {
+          showToast('Failed to delete this and following events. The series was kept.')
           return
         }
       }

--- a/src/features/calendar/components/EventPreviewPopup.tsx
+++ b/src/features/calendar/components/EventPreviewPopup.tsx
@@ -59,7 +59,12 @@ export function EventPreviewPopup({
   }, [closePreview, isClosing, prefersReducedMotion])
   const deleteEvent = useCalendarStore((state) => state.deleteEvent)
   const updateEvent = useCalendarStore((state) => state.updateEvent)
-  const { updateEvent: updateCalDAVEvent, deleteEvent: deleteCalDAVEvent } = useCalDAV()
+  const {
+    createEvent: createCalDAVEvent,
+    updateEvent: updateCalDAVEvent,
+    saveRecurrenceOverride,
+    deleteEvent: deleteCalDAVEvent,
+  } = useCalDAV()
   const originalEventId = extractOriginalEventId(clickedEventId)
   const eventIdToUse = originalEventId || event.id
 
@@ -235,15 +240,29 @@ export function EventPreviewPopup({
       )
 
       if (existingException) {
-        updateEvent(clickedEventId, pendingUpdates)
+        if (!masterEvent) {
+          showToast('Master event not found. Cannot edit single occurrence.')
+          return
+        }
+        const masterWithoutLegacyExdate = {
+          ...masterEvent,
+          excludedDates: masterEvent.excludedDates?.filter(
+            (date) => date.split('T')[0] !== occurrenceDateStr
+          ),
+        }
         try {
-          await updateCalDAVEvent(event.calendarId, { ...existingException, ...pendingUpdates })
+          await saveRecurrenceOverride(event.calendarId, masterWithoutLegacyExdate, {
+            ...existingException,
+            ...pendingUpdates,
+          })
         } catch {
-          // error handled by useCalDAV
+          showToast('Failed to update this occurrence. The original event was kept.')
+          return
         }
       } else {
         const exceptionEvent: CalendarEvent = {
           id: clickedEventId,
+          uid: masterEvent?.uid || masterEvent?.id || event.uid || event.id,
           title: pendingUpdates.title ?? event.title,
           description: pendingUpdates.description ?? event.description,
           location: pendingUpdates.location ?? event.location,
@@ -254,24 +273,24 @@ export function EventPreviewPopup({
           recurrence: undefined,
           rruleString: undefined,
           recurrenceId: occurrenceStartISO,
-        }
-        store.addEvent(exceptionEvent)
-        try {
-          await updateCalDAVEvent(event.calendarId, exceptionEvent)
-        } catch {
-          // error handled by useCalDAV
+          recurrenceMasterId: originalEventId || eventIdToUse,
         }
         if (masterEvent) {
-          const excluded = masterEvent.excludedDates || []
-          if (!excluded.includes(occurrenceDateStr)) {
-            const updatedExcludedDates = [...excluded, occurrenceDateStr]
-            updateEvent(masterEvent.id, { excludedDates: updatedExcludedDates })
-            safeCalDAVUpdate(
-              updateCalDAVEvent,
-              masterEvent.calendarId,
-              { ...masterEvent, excludedDates: updatedExcludedDates },
-              { excludedDates: updatedExcludedDates }
+          const masterWithoutLegacyExdate = {
+            ...masterEvent,
+            excludedDates: masterEvent.excludedDates?.filter(
+              (date) => date.split('T')[0] !== occurrenceDateStr
+            ),
+          }
+          try {
+            await saveRecurrenceOverride(
+              event.calendarId,
+              masterWithoutLegacyExdate,
+              exceptionEvent
             )
+          } catch {
+            showToast('Failed to update this occurrence. The original event was kept.')
+            return
           }
         }
       }
@@ -309,7 +328,7 @@ export function EventPreviewPopup({
       }
       store.addEvent(newSeriesEvent)
       try {
-        await updateCalDAVEvent(masterEvent.calendarId, newSeriesEvent)
+        await createCalDAVEvent(masterEvent.calendarId, newSeriesEvent)
       } catch {
         // error handled by useCalDAV
       }
@@ -331,7 +350,8 @@ export function EventPreviewPopup({
       }
       updateEvent(eventIdToUse, allUpdates)
       try {
-        await updateCalDAVEvent(event.calendarId, { ...event, ...allUpdates })
+        const eventToSync = masterEvent || event
+        await updateCalDAVEvent(eventToSync.calendarId, { ...eventToSync, ...allUpdates })
       } catch {
         // error handled by useCalDAV
       }
@@ -421,37 +441,44 @@ export function EventPreviewPopup({
       return
     }
     const idToDelete = originalEventId || event.id
-    deleteEvent(idToDelete)
     await safeCalDAVDelete(deleteCalDAVEvent, event.calendarId, idToDelete)
+    deleteEvent(idToDelete)
     closePreview()
   }
 
-  const performDelete = (mode: 'all' | 'this' | 'future'): void => {
+  const performDelete = async (mode: 'all' | 'this' | 'future'): Promise<void> => {
     if (mode === 'this' && originalEventId) {
       // For 'this' occurrence: exclude the date from the master event
       const occurrenceStartISO = clickedEventId.slice(originalEventId.length + 1)
       const occurrenceDate = occurrenceStartISO.split('T')[0]
-      const masterEvent = useCalendarStore.getState().events.find((e) => e.id === originalEventId)
+      const storedEvents = useCalendarStore.getState().events
+      const masterEvent = storedEvents.find((e) => e.id === originalEventId)
       if (masterEvent) {
+        const selectedException = storedEvents.find((candidate) => candidate.id === clickedEventId)
+        const exclusionValue = masterEvent.isAllDay ? occurrenceDate : occurrenceStartISO
         const excludedDates = masterEvent.excludedDates || []
-        if (!excludedDates.includes(occurrenceDate)) {
-          const updatedExcludedDates = [...excludedDates, occurrenceDate]
-          updateEvent(originalEventId, { excludedDates: updatedExcludedDates })
-          safeCalDAVUpdate(
-            updateCalDAVEvent,
+        const updatedExcludedDates = excludedDates.includes(exclusionValue)
+          ? excludedDates
+          : [...excludedDates, exclusionValue]
+        try {
+          await saveRecurrenceOverride(
             masterEvent.calendarId,
             { ...masterEvent, excludedDates: updatedExcludedDates },
-            { excludedDates: updatedExcludedDates }
+            null,
+            selectedException?.recurrenceId ? selectedException.id : undefined
           )
+        } catch {
+          showToast('Failed to delete this occurrence. The event was kept.')
+          return
         }
       }
     } else {
       // Delete entire series
       const idToDelete = originalEventId || event.id
-      deleteEvent(idToDelete)
       if (event.calendarId && event.calendarId !== 'default') {
-        safeCalDAVDelete(deleteCalDAVEvent, event.calendarId, idToDelete)
+        await safeCalDAVDelete(deleteCalDAVEvent, event.calendarId, idToDelete)
       }
+      deleteEvent(idToDelete)
     }
     closePreview()
     setShowDeleteDialog(false)

--- a/src/features/calendar/components/EventPreviewPopup.tsx
+++ b/src/features/calendar/components/EventPreviewPopup.tsx
@@ -203,6 +203,23 @@ export function EventPreviewPopup({
       }
     }
 
+    if (event.recurrenceId && originalEventId) {
+      const masterEvent = useCalendarStore.getState().events.find((candidate) => candidate.id === originalEventId)
+      if (!masterEvent) {
+        showToast('Master event not found. Cannot edit this occurrence.')
+        return
+      }
+      try {
+        await saveRecurrenceOverride(event.calendarId, masterEvent, { ...event, ...updates })
+      } catch {
+        showToast('Failed to update this occurrence. The original event was kept.')
+        return
+      }
+      setHasChanges(false)
+      setEditingField(null)
+      return
+    }
+
     const recurring = !!event.recurrence || !!event.rruleString || !!originalEventId
     if (recurring) {
       setPendingUpdates(updates)
@@ -433,9 +450,13 @@ export function EventPreviewPopup({
     openModal(undefined, undefined, clickedEventId)
   }
 
-  const isRecurring = !!event.recurrence || !!event.rruleString || !!originalEventId
+  const isRecurring = !event.recurrenceId && (!!event.recurrence || !!event.rruleString || !!originalEventId)
 
   const handleDelete = async (): Promise<void> => {
+    if (event.recurrenceId) {
+      await performDelete('this')
+      return
+    }
     if (isRecurring) {
       setShowDeleteDialog(true)
       return

--- a/src/features/calendar/components/eventModalState.ts
+++ b/src/features/calendar/components/eventModalState.ts
@@ -102,6 +102,12 @@ export function getInitialFormState(
   if (isEditing && selectedEventId) {
     existingEvent = events.find((e) => e.id === selectedEventId)
 
+    if (existingEvent?.recurrenceId) {
+      isRecurringInstance = true
+      originalEventId =
+        existingEvent.recurrenceMasterId || existingEvent.uid || extractOriginalEventId(selectedEventId)
+    }
+
     if (!existingEvent) {
       const originalId = extractOriginalEventId(selectedEventId)
       if (originalId) {

--- a/src/lib/__tests__/findEventById.test.ts
+++ b/src/lib/__tests__/findEventById.test.ts
@@ -15,6 +15,8 @@ describe('findEventById', () => {
 
   it('falls back to the recurrence master for a generated instance id', () => {
     expect(findEventById(events, instanceId)).toBe(master)
+    expect(findEventById(events, 'abc-2026-03-10T15:00:00')).toBe(master)
+    expect(findEventById(events, 'abc-2026-03-10T15:00:00Z')).toBe(master)
   })
 
   // All-day recurring instances are encoded as `<masterId>-<YYYY-MM-DD>` (no

--- a/src/lib/__tests__/recurrenceSplit.test.ts
+++ b/src/lib/__tests__/recurrenceSplit.test.ts
@@ -1,19 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 
-// R5.2 — the function uses `format(date, "yyyy-MM-dd'T'23:59:59'Z'")` from
-// date-fns, which formats in the system's *local* timezone. To make these
-// tests deterministic across timezones (the test environment may be UTC,
-// UTC+2, etc.), we override `format` to return the date's UTC ISO string.
-// All other date-fns exports are preserved via `importActual`.
-vi.mock('date-fns', async () => {
-  const actual = await vi.importActual<typeof import('date-fns')>('date-fns')
-  return {
-    ...actual,
-    format: (date: Date): string => date.toISOString(),
-  }
-})
-
-import { buildMasterTruncation } from '../recurrenceSplit'
+import { buildMasterTruncation, getFutureOverrideIds, isFirstOccurrence } from '../recurrenceSplit'
 import { makeEvent, makeRule } from './fixtures'
 import type { CalendarEvent } from '@/types'
 
@@ -40,14 +27,48 @@ describe('buildMasterTruncation (R5.2: do not pollute excludedDates)', () => {
     expect(result.excludedDates).toEqual(['2026-03-01', '2026-03-08'])
   })
 
-  it('sets recurrence.endDate to the day before occurrenceDateStr (truncation does the work)', () => {
+  it('sets recurrence.endDate immediately before the selected occurrence', () => {
     const master = makeEvent({ recurrence: makeRule({ frequency: 'weekly' }) })
     const result = buildMasterTruncation(master, '2026-04-15')
-    // With format() mocked to return date.toISOString(), the dayBefore
-    // Date object is 2026-04-14T00:00:00.000Z, so endDate must be that.
-    // This proves the master will not generate on the split date — which
-    // is precisely why the EXDATE push (R5.2) was redundant.
-    expect(result.recurrence?.endDate).toBe('2026-04-14T00:00:00.000Z')
+    expect(result.recurrence?.endDate).toBe('2026-04-15T08:59:59.000Z')
+  })
+
+  it('uses the event timezone when truncating a timed series', () => {
+    const master = makeEvent({
+      start: '2026-04-01T23:30:00',
+      end: '2026-04-02T00:30:00',
+      timezone: 'America/Los_Angeles',
+      recurrence: makeRule({ frequency: 'daily' }),
+    })
+
+    const result = buildMasterTruncation(master, '2026-04-15T23:30:00')
+
+    expect(result.recurrence?.endDate).toBe('2026-04-16T06:29:59.000Z')
+  })
+
+  it('reinterprets generated UTC-shaped occurrence IDs in the series timezone', () => {
+    const master = makeEvent({
+      start: '2026-04-01T23:30:00',
+      end: '2026-04-02T00:30:00',
+      timezone: 'America/Los_Angeles',
+      recurrence: makeRule({ frequency: 'hourly' }),
+    })
+
+    const generatedOccurrenceId = new Date('2026-04-15T23:30:00').toISOString()
+    const result = buildMasterTruncation(master, generatedOccurrenceId)
+
+    expect(result.recurrence?.endDate).toBe('2026-04-16T06:29:59.000Z')
+  })
+
+  it('truncates an RRULE-string-only series without removing recurrence', () => {
+    const master = makeEvent({
+      recurrence: undefined,
+      rruleString: 'FREQ=HOURLY;COUNT=20',
+    })
+
+    const result = buildMasterTruncation(master, '2026-04-15T15:00:00Z')
+
+    expect(result.rruleString).toBe('FREQ=HOURLY;UNTIL=20260415T145959Z')
   })
 
   it('does not mutate the master event (pure function)', () => {
@@ -67,5 +88,81 @@ describe('buildMasterTruncation (R5.2: do not pollute excludedDates)', () => {
     // preserved (no in-place mutation or replacement on the input).
     expect(master.recurrence).toBe(recurrence)
     expect(master.excludedDates).toBe(excludedDates)
+  })
+})
+
+describe('isFirstOccurrence', () => {
+  it('recognizes a generated first occurrence for a TZID series', () => {
+    const master = makeEvent({
+      start: '2026-04-15T23:30:00',
+      end: '2026-04-16T00:30:00',
+      timezone: 'America/Los_Angeles',
+    })
+    const generatedOccurrenceId = new Date(master.start).toISOString()
+
+    expect(isFirstOccurrence(master, generatedOccurrenceId)).toBe(true)
+  })
+
+  it('does not treat a later occurrence as the first', () => {
+    const master = makeEvent({ start: '2026-04-15T09:00:00Z' })
+    expect(isFirstOccurrence(master, '2026-04-16T09:00:00Z')).toBe(false)
+  })
+})
+
+describe('getFutureOverrideIds', () => {
+  it('returns only overrides from the selected occurrence onward', () => {
+    const master = makeEvent({ id: 'series', uid: 'series-uid' })
+    const events = [
+      master,
+      makeEvent({
+        id: 'past',
+        uid: 'series-uid',
+        recurrenceId: '2026-04-08T09:00:00.000Z',
+        recurrenceMasterId: master.id,
+      }),
+      makeEvent({
+        id: 'selected',
+        uid: 'series-uid',
+        recurrenceId: '2026-04-15T09:00:00.000Z',
+        recurrenceMasterId: master.id,
+      }),
+      makeEvent({
+        id: 'future',
+        uid: 'series-uid',
+        recurrenceId: '2026-04-22T09:00:00.000Z',
+        recurrenceMasterId: master.id,
+      }),
+      makeEvent({
+        id: 'other-series',
+        uid: 'other-series',
+        recurrenceId: '2026-04-22T09:00:00.000Z',
+      }),
+      makeEvent({
+        id: 'other-calendar',
+        uid: 'series-uid',
+        calendarId: 'other-calendar',
+        recurrenceId: '2026-04-22T09:00:00.000Z',
+      }),
+    ]
+
+    expect(getFutureOverrideIds(events, master, '2026-04-15')).toEqual([
+      'selected',
+      'future',
+    ])
+  })
+
+  it('preserves earlier overrides from the same day for sub-daily recurrence', () => {
+    const master = makeEvent({ id: 'hourly', uid: 'hourly', rruleString: 'FREQ=HOURLY' })
+    const events = [
+      master,
+      makeEvent({ id: 'morning', uid: 'hourly', recurrenceId: '2026-04-15T09:00:00Z' }),
+      makeEvent({ id: 'selected', uid: 'hourly', recurrenceId: '2026-04-15T15:00:00Z' }),
+      makeEvent({ id: 'later', uid: 'hourly', recurrenceId: '2026-04-15T18:00:00Z' }),
+    ]
+
+    expect(getFutureOverrideIds(events, master, '2026-04-15T15:00:00Z')).toEqual([
+      'selected',
+      'later',
+    ])
   })
 })

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -16,7 +16,7 @@
  */
 export function extractOriginalEventId(eventId: string): string | null {
   const isoTimestampMatch = eventId.match(
-    /(.+)-(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)$/
+    /(.+)-(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z?)$/
   )
   if (isoTimestampMatch) {
     return isoTimestampMatch[1]

--- a/src/lib/recurrenceSplit.ts
+++ b/src/lib/recurrenceSplit.ts
@@ -1,3 +1,4 @@
+import { fromZonedTime } from 'date-fns-tz'
 import { format } from 'date-fns'
 import { buildRRuleString } from '@/lib/recurrence'
 import type { CalendarEvent, RecurrenceRule } from '@/types'
@@ -11,39 +12,103 @@ export interface MasterTruncation {
 /**
  * Computes the patch to apply to a recurrence master when splitting a series at
  * a given occurrence ("This and following events"). The master keeps every
- * occurrence *before* the split by ending its recurrence the day before, and
- * excludes the split date itself (a new series takes over from there).
+ * occurrence before the split by ending immediately before that occurrence.
  *
  * Pure — it neither mutates the store nor calls CalDAV. Callers apply the
  * returned patch (via `updateEvent`) and separately create the new series.
  *
  * @param master           the recurrence master event
- * @param occurrenceDateStr the split occurrence date, `yyyy-MM-dd`
+ * @param occurrenceValue the selected occurrence's RECURRENCE-ID value
  */
 export function buildMasterTruncation(
   master: CalendarEvent,
-  occurrenceDateStr: string
+  occurrenceValue: string
 ): MasterTruncation {
-  // End the master the day before the split point, in UTC. The 'Z' literal
-  // keeps it in UTC and avoids an off-by-one from local-time interpretation.
-  const splitDate = new Date(`${occurrenceDateStr}T00:00:00Z`)
-  const dayBefore = new Date(splitDate)
-  dayBefore.setUTCDate(dayBefore.getUTCDate() - 1)
-  const masterEndDate = format(dayBefore, "yyyy-MM-dd'T'23:59:59'Z'")
+  const occurrenceDateStr = occurrenceValue.split('T')[0]
+  let masterEndDate: string
+  let untilValue: string
 
-  // R5.2 — the master is already truncated to the day before the split
-  // point (masterEndDate below), so it will not generate any occurrence
-  // on or after occurrenceDateStr. Adding occurrenceDateStr to
-  // excludedDates was a no-op that polluted the master's EXDATE list on
-  // every "this and following events" split. Drop the push; the master
-  // is correct without it.
+  if (master.isAllDay) {
+    const dayBefore = new Date(`${occurrenceDateStr}T00:00:00Z`)
+    dayBefore.setUTCDate(dayBefore.getUTCDate() - 1)
+    masterEndDate = dayBefore.toISOString().split('T')[0]
+    untilValue = masterEndDate.replaceAll('-', '')
+  } else {
+    const occurrence = parseOccurrenceValue(master, occurrenceValue)
+    const immediatelyBefore = new Date(occurrence.getTime() - 1000)
+    masterEndDate = immediatelyBefore.toISOString()
+    untilValue = masterEndDate.replace(/[-:]/g, '').replace('.000', '')
+  }
+
+  // The UNTIL boundary already excludes the selected occurrence, so adding an
+  // EXDATE would only pollute the master and is unnecessary.
   const excludedDates = master.excludedDates || []
 
   const recurrence: RecurrenceRule | undefined = master.recurrence
     ? { ...master.recurrence, endDate: masterEndDate, count: undefined, isAllDay: master.isAllDay }
     : undefined
 
-  const rruleString = recurrence ? buildRRuleString(recurrence) : undefined
+  const rruleString = recurrence
+    ? buildRRuleString(recurrence)
+    : master.rruleString
+      ? [
+          ...master.rruleString
+            .split(';')
+            .filter((part) => {
+              const normalized = part.toUpperCase()
+              return !normalized.startsWith('UNTIL=') && !normalized.startsWith('COUNT=')
+            }),
+          `UNTIL=${untilValue}`,
+        ].join(';')
+      : undefined
 
   return { excludedDates, recurrence, rruleString }
+}
+
+export function getFutureOverrideIds(
+  events: readonly CalendarEvent[],
+  master: CalendarEvent,
+  occurrenceValue: string
+): string[] {
+  const uid = master.uid || master.id
+  const boundary = master.isAllDay
+    ? occurrenceValue.split('T')[0]
+    : parseOccurrenceValue(master, occurrenceValue).getTime()
+  return events
+    .filter(
+      (event) =>
+        Boolean(event.recurrenceId) &&
+        event.calendarId === master.calendarId &&
+        (event.recurrenceMasterId === master.id || event.uid === uid) &&
+        (master.isAllDay
+          ? event.recurrenceId!.split('T')[0] >= (boundary as string)
+          : parseOccurrenceValue(master, event.recurrenceId!).getTime() >= (boundary as number))
+    )
+    .map((event) => event.id)
+}
+
+export function isFirstOccurrence(master: CalendarEvent, occurrenceValue: string): boolean {
+  if (master.isAllDay) {
+    return occurrenceValue.split('T')[0] <= master.start.split('T')[0]
+  }
+  return parseOccurrenceValue(master, occurrenceValue).getTime() <=
+    parseOccurrenceValue(master, master.start).getTime()
+}
+
+function parseOccurrenceValue(master: CalendarEvent, value: string): Date {
+  let normalized = value
+  if (!normalized.includes('T')) {
+    const masterTime = master.start.split('T')[1] || '00:00:00'
+    normalized = `${normalized}T${masterTime}`
+  }
+  if (master.timezone && master.timezone !== 'UTC') {
+    // Generated occurrence IDs use Date#toISOString even when DTSTART has a
+    // TZID. Convert them back to the browser wall clock used by expansion, then
+    // reinterpret that clock in the series timezone before writing UNTIL.
+    const wallClock = normalized.endsWith('Z')
+      ? format(new Date(normalized), "yyyy-MM-dd'T'HH:mm:ss")
+      : normalized
+    return fromZonedTime(wallClock, master.timezone)
+  }
+  return new Date(normalized)
 }

--- a/src/store/__tests__/calendarStore.test.ts
+++ b/src/store/__tests__/calendarStore.test.ts
@@ -582,6 +582,44 @@ it('closes modal', () => {
       const weeklySyncEvents = events.filter((e) => e.title === 'Weekly Sync')
       expect(weeklySyncEvents.length).toBe(2)
     })
+
+    it('does not apply an exception to another recurring series at the same time', () => {
+      const store = useCalendarStore.getState()
+      store.addEvent({ id: 'master-a', calendarId: 'default', title: 'Series A', start: '2024-03-18T09:00:00.000Z', end: '2024-03-18T10:00:00.000Z', isAllDay: false, recurrence: { frequency: 'weekly', interval: 1 } })
+      store.addEvent({ id: 'master-b', calendarId: 'default', title: 'Series B', start: '2024-03-18T09:00:00.000Z', end: '2024-03-18T10:00:00.000Z', isAllDay: false, recurrence: { frequency: 'weekly', interval: 1 } })
+      store.addEvent({ id: 'master-a-2024-03-18T09:00:00.000Z', calendarId: 'default', title: 'Edited Series A', start: '2024-03-18T11:00:00.000Z', end: '2024-03-18T12:00:00.000Z', isAllDay: false, recurrenceId: '2024-03-18T09:00:00.000Z', recurrenceMasterId: 'master-a' })
+
+      const events = store.getEventsForDateRange('2024-03-18', '2024-03-18')
+      expect(events.map((event) => event.title).sort()).toEqual(['Edited Series A', 'Series B'])
+    })
+
+    it('shows a detached occurrence in the range it was moved to', () => {
+      const store = useCalendarStore.getState()
+      store.addEvent({ id: 'moved-master', calendarId: 'default', title: 'Weekly meeting', start: '2024-03-18T09:00:00.000Z', end: '2024-03-18T10:00:00.000Z', isAllDay: false, recurrence: { frequency: 'weekly', interval: 1 } })
+      store.addEvent({ id: 'moved-master-2024-03-18T09:00:00.000Z', uid: 'moved-master', calendarId: 'default', title: 'Moved meeting', start: '2024-03-19T11:00:00.000Z', end: '2024-03-19T12:00:00.000Z', isAllDay: false, recurrenceId: '2024-03-18T09:00:00.000Z', recurrenceMasterId: 'moved-master' })
+
+      expect(store.getEventsForDateRange('2024-03-19', '2024-03-19')).toMatchObject([
+        { title: 'Moved meeting', start: '2024-03-19T11:00:00.000Z' },
+      ])
+      expect(store.getEventsForDateRange('2024-03-18', '2024-03-18')).toHaveLength(0)
+    })
+
+    it('matches a floating recurrence ID to the generated occurrence', () => {
+      const store = useCalendarStore.getState()
+      store.addEvent({ id: 'floating-master', calendarId: 'default', title: 'Original', start: '2024-03-18T09:00:00', end: '2024-03-18T10:00:00', isAllDay: false, recurrence: { frequency: 'weekly', interval: 1 } })
+      store.addEvent({ id: 'floating-master-2024-03-18T09:00:00', uid: 'floating-master', calendarId: 'default', title: 'Moved', start: '2024-03-19T11:00:00', end: '2024-03-19T12:00:00', isAllDay: false, recurrenceId: '2024-03-18T09:00:00', recurrenceMasterId: 'floating-master' })
+
+      const events = store.getEventsForDateRange('2024-03-18', '2024-03-19')
+      expect(events.map((event) => event.title)).toEqual(['Moved'])
+    })
+
+    it('suppresses a cancelled detached occurrence without rendering it', () => {
+      const store = useCalendarStore.getState()
+      store.addEvent({ id: 'cancelled-master', calendarId: 'default', title: 'Weekly', start: '2024-03-18T09:00:00.000Z', end: '2024-03-18T10:00:00.000Z', isAllDay: false, recurrence: { frequency: 'weekly', interval: 1 } })
+      store.addEvent({ id: 'cancelled-master-2024-03-18T09:00:00.000Z', uid: 'cancelled-master', calendarId: 'default', title: 'Cancelled', start: '2024-03-18T09:00:00.000Z', end: '2024-03-18T10:00:00.000Z', isAllDay: false, recurrenceId: '2024-03-18T09:00:00.000Z', recurrenceMasterId: 'cancelled-master', eventStatus: 'CANCELLED' })
+
+      expect(store.getEventsForDateRange('2024-03-18', '2024-03-18')).toHaveLength(0)
+    })
   })
 
   // ======================================================================
@@ -962,8 +1000,10 @@ it('closes modal', () => {
         end: '2024-03-25T15:00:00.000Z',
         isAllDay: false,
         recurrenceId: '2024-03-25T09:00:00.000Z',
+        recurrenceMasterId: 'master-event',
         syncStatus: 'synced',
         etag: '"abc123"',
+        resourceHref: 'https://example.com/event.ics',
         sequence: 1,
       })
 
@@ -975,10 +1015,12 @@ it('closes modal', () => {
 
       // recurrenceId should be cleared
       expect(duplicate.recurrenceId).toBeUndefined()
+      expect(duplicate.recurrenceMasterId).toBeUndefined()
       // syncStatus should be cleared
       expect(duplicate.syncStatus).toBeUndefined()
       // etag should be cleared
       expect(duplicate.etag).toBeUndefined()
+      expect(duplicate.resourceHref).toBeUndefined()
       // sequence should be cleared
       expect(duplicate.sequence).toBeUndefined()
 
@@ -1254,8 +1296,8 @@ it('closes modal', () => {
     })
   })
 
-  describe('Bug 40: excluded dates check compares date portions only', () => {
-    it('excludes occurrence when excluded date has different time suffix', () => {
+  describe('timed recurrence exclusions', () => {
+    it('does not exclude a timed occurrence when EXDATE is midnight', () => {
       const store = useCalendarStore.getState()
 
       store.addEvent({
@@ -1272,9 +1314,9 @@ it('closes modal', () => {
 
       const events = store.getEventsForDateRange('2024-03-18', '2024-04-01')
 
-      // March 25 should be excluded even though excluded date has different time
+      // RFC 5545 requires EXDATE to match the original occurrence value.
       const march25 = events.find((e) => e.start.startsWith('2024-03-25'))
-      expect(march25).toBeUndefined()
+      expect(march25).toBeDefined()
 
       // March 18 and April 1 should still appear
       const march18 = events.find((e) => e.start.startsWith('2024-03-18'))
@@ -1283,7 +1325,7 @@ it('closes modal', () => {
       expect(apr1).toBeDefined()
     })
 
-    it('excludes occurrence when excluded date is date-only string', () => {
+    it('does not exclude a timed occurrence with a date-only EXDATE', () => {
       const store = useCalendarStore.getState()
 
       store.addEvent({
@@ -1300,12 +1342,30 @@ it('closes modal', () => {
 
       const events = store.getEventsForDateRange('2024-04-01', '2024-04-05')
 
-      // April 3 should be excluded (date-only in excludedDates matches the occurrence date)
+      // A DATE value cannot exclude a DATE-TIME occurrence.
       const apr3 = events.find((e) => e.start.startsWith('2024-04-03'))
-      expect(apr3).toBeUndefined()
+      expect(apr3).toBeDefined()
 
       // Other dates should appear
-      expect(events.length).toBe(4)
+      expect(events.length).toBe(5)
+    })
+
+    it('excludes a timed occurrence when EXDATE matches its exact start', () => {
+      const store = useCalendarStore.getState()
+      store.addEvent({
+        id: 'master-exact-exdate',
+        calendarId: 'default',
+        title: 'Lunch',
+        start: '2026-07-13T15:20:00.000Z',
+        end: '2026-07-13T16:10:00.000Z',
+        isAllDay: false,
+        rruleString: 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR',
+        excludedDates: ['2026-07-22T15:20:00.000Z'],
+      })
+
+      const events = store.getEventsForDateRange('2026-07-22', '2026-07-23')
+      expect(events.some((event) => event.start === '2026-07-22T15:20:00.000Z')).toBe(false)
+      expect(events.some((event) => event.start === '2026-07-23T15:20:00.000Z')).toBe(true)
     })
 
     it('does not exclude occurrence when excluded date differs from occurrence date', () => {

--- a/src/store/calendarStore.ts
+++ b/src/store/calendarStore.ts
@@ -352,8 +352,10 @@ export const useCalendarStore = create<CalendarStore>()(
         const newEvent: CalendarEvent = {
           ...eventToDuplicate,
           id: crypto.randomUUID(),
+          uid: undefined,
           title: addCopySuffix ? `${eventToDuplicate.title} (copy)` : eventToDuplicate.title,
           recurrenceId: undefined,
+          recurrenceMasterId: undefined,
           isFragment: undefined,
           isFirstFragment: undefined,
           isLastFragment: undefined,
@@ -362,6 +364,7 @@ export const useCalendarStore = create<CalendarStore>()(
           originalEnd: undefined,
           syncStatus: undefined,
           etag: undefined,
+          resourceHref: undefined,
           sequence: undefined,
         }
 
@@ -654,11 +657,26 @@ export const useCalendarStore = create<CalendarStore>()(
         const seenIds = new Set<string>()
 
         const exceptionMap = new Map<string, CalendarEvent>()
+        const legacyExceptionMap = new Map<string, CalendarEvent>()
+        const recurringMasters = new Map(
+          state.events
+            .filter((event) => !event.recurrenceId)
+            .map((event) => [event.id, event])
+        )
         for (const event of state.events) {
           if (event.recurrenceId && visibleCalendarIds.includes(event.calendarId)) {
-            const dateKey = event.recurrenceId.split('T')[0]
-            const key = `${event.calendarId}-${dateKey}`
-            exceptionMap.set(key, event)
+            const inferredMasterId = event.id.endsWith(`-${event.recurrenceId}`)
+              ? event.id.slice(0, -(event.recurrenceId.length + 1))
+              : undefined
+            const masterId = event.recurrenceMasterId || inferredMasterId
+            if (masterId) {
+              const recurrenceKey = event.isAllDay
+                ? event.recurrenceId.split('T')[0]
+                : parseISO(event.recurrenceId).getTime()
+              exceptionMap.set(`${event.calendarId}-${masterId}-${recurrenceKey}`, event)
+            } else {
+              legacyExceptionMap.set(`${event.calendarId}-${event.recurrenceId.split('T')[0]}`, event)
+            }
           }
         }
 
@@ -687,7 +705,17 @@ export const useCalendarStore = create<CalendarStore>()(
           if (!visibleCalendarIds.includes(event.calendarId)) {
             continue
           }
-          if (selectedCategoryNames.length > 0 && !event.categories?.some((c) => selectedCategoryNames.includes(c))) {
+          if (event.eventStatus === 'CANCELLED') {
+            continue
+          }
+          const categorySource = event.recurrenceId
+            ? recurringMasters.get(event.recurrenceMasterId || event.uid || '')
+            : event
+          if (
+            selectedCategoryNames.length > 0 &&
+            categorySource &&
+            !categorySource.categories?.some((category) => selectedCategoryNames.includes(category))
+          ) {
             continue
           }
 
@@ -753,24 +781,21 @@ export const useCalendarStore = create<CalendarStore>()(
 
                 // Check for exception first — if one exists for this date, use it
                 // regardless of whether the date is also in excludedDates.
-                const exceptionKey = `${event.calendarId}-${occDateStr}`
-                const exception = exceptionMap.get(exceptionKey)
+                const recurrenceValue = event.isAllDay ? occDateStr : occ.getTime()
+                const exception =
+                  exceptionMap.get(`${event.calendarId}-${event.id}-${recurrenceValue}`) ||
+                  legacyExceptionMap.get(`${event.calendarId}-${occDateStr}`)
                 if (exception) {
-                  const occId = `${event.id}-${occKey}`
-                  if (!seenIds.has(occId)) {
-                    seenIds.add(occId)
-                    expandedEvents.push({
-                      ...exception,
-                      id: occId,
-                      start: exception.start,
-                      end: exception.end,
-                    })
-                  }
+                  // The detached instance is rendered independently at its
+                  // actual start below. Here it only suppresses the master slot.
                   continue
                 }
 
                 // No exception — honour EXDATE exclusions
-                if (excludedDates.some(d => d.split('T')[0] === occDateStr)) {
+                const isExcluded = event.isAllDay
+                  ? excludedDates.some((date) => date.split('T')[0] === occDateStr)
+                  : excludedDates.some((date) => parseISO(date).getTime() === occ.getTime())
+                if (isExcluded) {
                   continue
                 }
 
@@ -798,9 +823,6 @@ export const useCalendarStore = create<CalendarStore>()(
               }
             }
           } else {
-            if (event.recurrenceId) {
-              continue
-            }
             const eventStart = eventStartDates.get(event.id)!
             const eventEnd = eventEndDates.get(event.id)!
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,6 +83,8 @@ export interface DuplicateUidIssue {
 
 export interface CalendarEvent {
   id: string
+  /** RFC 5545 UID. Detached recurrence instances share this with their master. */
+  uid?: string
   calendarId: string
   title: string
   description?: string
@@ -105,8 +107,14 @@ export interface CalendarEvent {
   transparency?: 'opaque' | 'transparent'
   sequence?: number
   etag?: string
+  /** Exact CalDAV object URL used for update/delete; it is not derived from UID. */
+  resourceHref?: string
   excludedDates?: string[]
   recurrenceId?: string
+  /** Local master identity for a detached recurrence occurrence. */
+  recurrenceMasterId?: string
+  /** Raw VEVENT STATUS value, including cancelled detached occurrences. */
+  eventStatus?: string
   isFragment?: boolean
   isFirstFragment?: boolean
   isLastFragment?: boolean


### PR DESCRIPTION
## Summary

This PR fixes a series of issues related to recurring event editing and CalDAV synchronization.
Editing a single occurrence could previously create “ghost events” in Calino. These events could also appear in other CalDAV clients and lead to duplicated, missing, or inconsistent recurring occurrences. While fixing the original issue, several related problems were identified and corrected.
This PR also adds the “This and following events” option when deleting a recurring event.

## Changes

- Preserve recurring masters and detached occurrences sharing the same UID.
- Store master and recurrence overrides in the same CalDAV resource.
- Prevent ghost and duplicated events after editing a single occurrence.
- Preserve the original CalDAV resource URL for updates and deletions.
- Correct timed EXDATE matching.
- Preserve moved and cancelled recurrence overrides.
- Support UTC, floating, and timezone-aware recurrence IDs.
- Prevent unrelated recurring series from sharing overrides.
- Add “This and following events” to recurring event deletion.
- Preserve occurrences before the selected event.
- Remove the selected occurrence, future occurrences, and their overrides.
- Handle all-day, timezone-aware, sub-daily, and RRULE-only series.

## Testing

- Added unit coverage for recurrence parsing, expansion, grouped CalDAV updates, timezone boundaries, and future override deletion.
- Added Playwright coverage for recurring event editing, CalDAV round trips, and deleting this and following occurrences.
- TypeScript and lint checks pass.