### PR TITLE
feat: parse compact times in event creation

### DIFF
--- a/e2e/time-format.spec.ts
+++ b/e2e/time-format.spec.ts
@@ -23,6 +23,17 @@ test.describe('time format in event form', () => {
     await expect(endTime).toHaveValue('3:30 PM')
   })
 
+  test('normalizes a compact 24-hour time when creating an event', async ({ page }) => {
+    await page.goto('/month')
+    await page.keyboard.press('c')
+
+    const startTime = page.locator('[data-component="event-start-time"]')
+    await startTime.fill('1140')
+    await startTime.press('Tab')
+
+    await expect(startTime).toHaveValue('11:40')
+  })
+
   test('uses the selected 12-hour format when creating a task', async ({ page }) => {
     await page.goto('/settings')
     await page.getByRole('radio', { name: '12-hour (2:30 PM)' }).click()

--- a/src/features/calendar/components/TimeInput.tsx
+++ b/src/features/calendar/components/TimeInput.tsx
@@ -20,10 +20,24 @@ function formatTimeValue(value: string, timeFormat: TimeFormat): string {
   return `${hours % 12 || 12}:${String(minutes).padStart(2, '0')} ${hours < 12 ? 'AM' : 'PM'}`
 }
 
-function parseTimeValue(value: string, timeFormat: TimeFormat): string | null {
+function parseTimeValue(
+  value: string,
+  timeFormat: TimeFormat,
+  allowCompact = false
+): string | null {
   if (timeFormat === '24h') {
-    const match = value.match(/^([01]\d|2[0-3]):([0-5]\d)$/)
-    return match ? `${match[1]}:${match[2]}` : null
+    const trimmedValue = value.trim()
+    const match = trimmedValue.match(/^([01]\d|2[0-3]):([0-5]\d)$/)
+    if (match) return `${match[1]}:${match[2]}`
+
+    if (allowCompact) {
+      const compactMatch = trimmedValue.match(/^(\d{1,2})([0-5]\d)$/)
+      if (compactMatch && Number(compactMatch[1]) <= 23) {
+        return `${compactMatch[1].padStart(2, '0')}:${compactMatch[2]}`
+      }
+    }
+
+    return null
   }
 
   const match = value.trim().match(/^(1[0-2]|0?[1-9]):([0-5]\d)\s*([AP]M)$/i)
@@ -51,7 +65,8 @@ export function TimeInput({
   }, [formattedValue])
 
   const commit = (): void => {
-    const parsed = parseTimeValue(draft, resolvedTimeFormat)
+    const parsed = parseTimeValue(draft, resolvedTimeFormat, true)
+    if (parsed && parsed !== value) onChange(parsed)
     setDraft(formatTimeValue(parsed ?? value, resolvedTimeFormat))
   }
 

--- a/src/features/calendar/components/__tests__/EventFormFields.test.tsx
+++ b/src/features/calendar/components/__tests__/EventFormFields.test.tsx
@@ -407,4 +407,40 @@ describe('EventFormFields', () => {
       expect(onEndTimeChange).toHaveBeenCalledWith('16:00')
     })
   })
+
+  describe('compact time input', () => {
+    it('normalizes a four-digit time on blur', () => {
+      const onStartTimeChange = vi.fn()
+      render(<EventFormFields {...defaultProps} onStartTimeChange={onStartTimeChange} />)
+
+      const startTime = screen.getByLabelText('Start time')
+      fireEvent.change(startTime, { target: { value: '1140' } })
+      fireEvent.blur(startTime)
+
+      expect(onStartTimeChange).toHaveBeenCalledWith('11:40')
+    })
+
+    it('normalizes a three-digit time on blur', () => {
+      const onStartTimeChange = vi.fn()
+      render(<EventFormFields {...defaultProps} onStartTimeChange={onStartTimeChange} />)
+
+      const startTime = screen.getByLabelText('Start time')
+      fireEvent.change(startTime, { target: { value: '940' } })
+      fireEvent.blur(startTime)
+
+      expect(onStartTimeChange).toHaveBeenCalledWith('09:40')
+    })
+
+    it('rejects an invalid compact time', () => {
+      const onStartTimeChange = vi.fn()
+      render(<EventFormFields {...defaultProps} onStartTimeChange={onStartTimeChange} />)
+
+      const startTime = screen.getByLabelText('Start time')
+      fireEvent.change(startTime, { target: { value: '2460' } })
+      fireEvent.blur(startTime)
+
+      expect(onStartTimeChange).not.toHaveBeenCalled()
+      expect(startTime).toHaveValue('09:00')
+    })
+  })
 })


### PR DESCRIPTION
Implemented automatic parsing of compact time inputs when creating events:
- 1140 → 11:40
- 940 → 09:40
- Invalid times, such as 2460, are rejected and the previous value is restored.
- Conversion occurs when the field loses focus or when Enter is pressed.