### PR TITLE
feat(carddav): resolve RELATED UUIDs to contact names in detail view

### DIFF
--- a/src/features/carddav/components/ContactDetail.tsx
+++ b/src/features/carddav/components/ContactDetail.tsx
@@ -4,6 +4,7 @@ import type { Contact } from '../types'
 import { useContactStore } from '@/store/contactStore'
 import { MarkdownView } from '@/lib/markdown'
 import { getInitials, getAvatarColor } from '../lib/avatars'
+import { resolveRelatedInAddressBook, isUrnUuid } from '../lib/resolveRelated'
 import styles from './ContactsView.module.css'
 
 // ---------------------------------------------------------------------------
@@ -123,6 +124,7 @@ interface ContactDetailProps {
   hasBirthdayEvent?: boolean
   onAddAnniversaryToCalendar?: () => void
   hasAnniversaryEvent?: boolean
+  onSelectRelated?: (contactId: string) => void
 }
 
 export function ContactDetail({
@@ -135,6 +137,7 @@ export function ContactDetail({
   hasBirthdayEvent = false,
   onAddAnniversaryToCalendar,
   hasAnniversaryEvent = false,
+  onSelectRelated,
 }: ContactDetailProps): JSX.Element {
   const [inlineEditing, setInlineEditing] = useState<InlineEdit | null>(null)
 
@@ -473,14 +476,36 @@ export function ContactDetail({
               {contact.related && contact.related.length > 0 && (
                 <div className={styles.infoField}>
                   <span className={styles.infoFieldLabel}>RELATED</span>
-                  {contact.related.map((rel, i) => (
-                    <div key={`rel-${i}`} className={styles.infoFieldGrid}>
-                      <span className={styles.infoFieldSub}>
-                        {RELATED_TYPE_LABELS[rel.type] ?? rel.type}
-                      </span>
-                      <span className={styles.infoFieldValue}>{rel.value}</span>
-                    </div>
-                  ))}
+                  {(() => {
+                    const allContacts = useContactStore.getState().contacts
+                    return contact.related.map((rel, i) => {
+                      const resolved = resolveRelatedInAddressBook(rel, contact, allContacts)
+                      return (
+                        <div key={`rel-${i}`} className={styles.infoFieldGrid}>
+                          <span className={styles.infoFieldSub}>
+                            {RELATED_TYPE_LABELS[rel.type] ?? rel.type}
+                          </span>
+                          <span className={styles.infoFieldValue}>
+                            {resolved ? (
+                              <button
+                                type="button"
+                                className={styles.relatedLink}
+                                onClick={() => onSelectRelated?.(resolved.id)}
+                              >
+                                {resolved.displayName}
+                              </button>
+                            ) : isUrnUuid(rel.value) ? (
+                              <span className={styles.relatedBroken}>
+                                Unresolved ({rel.value.replace('urn:uuid:', '')})
+                              </span>
+                            ) : (
+                              rel.value
+                            )}
+                          </span>
+                        </div>
+                      )
+                    })
+                  })()}
                 </div>
               )}
 

--- a/src/features/carddav/components/ContactsView.module.css
+++ b/src/features/carddav/components/ContactsView.module.css
@@ -343,6 +343,27 @@
   text-decoration: underline;
 }
 
+.relatedLink {
+  color: var(--accent, #b07d4f);
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+  line-height: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.14s;
+}
+
+.relatedLink:hover {
+  text-decoration: underline;
+}
+
+.relatedBroken {
+  opacity: 0.5;
+  font-style: italic;
+}
+
 /* ---- Notes Card ---- */
 .notesCard {
   background: var(--panel, #ffffff);

--- a/src/features/carddav/components/ContactsView.tsx
+++ b/src/features/carddav/components/ContactsView.tsx
@@ -99,6 +99,13 @@ export function ContactsView(): JSX.Element {
     setIsFormOpen(true)
   }, [])
 
+  const handleSelectRelated = useCallback(
+    (contactId: string): void => {
+      setSelectedContactId(contactId)
+    },
+    [setSelectedContactId],
+  )
+
   // Close the address book picker on outside click or Escape
   useEffect(() => {
     if (!showPicker) return
@@ -383,6 +390,7 @@ export function ContactsView(): JSX.Element {
             hasAnniversaryEvent={
               selectedContact.anniversary != null && hasAnniversaryEvent(selectedContact.id, events)
             }
+            onSelectRelated={handleSelectRelated}
           />
         ) : (
           !isMobile && (

--- a/src/features/carddav/lib/__tests__/resolveRelated.test.ts
+++ b/src/features/carddav/lib/__tests__/resolveRelated.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import { resolveRelatedInAddressBook, isUrnUuid } from '../resolveRelated'
+import type { Contact, ContactRelated } from '../../types'
+
+const MINIMAL_CONTACT = (overrides: Partial<Contact>): Contact => ({
+  id: 'default-id',
+  addressBookId: 'ab-1',
+  accountId: 'acc-1',
+  url: '/carddav/contact.vcf',
+  familyName: '',
+  givenName: '',
+  additionalNames: '',
+  prefixes: '',
+  suffixes: '',
+  nickname: '',
+  displayName: 'Test Contact',
+  organization: '',
+  department: '',
+  title: '',
+  role: '',
+  emails: [],
+  phones: [],
+  addresses: [],
+  urls: [],
+  ims: [],
+  birthday: null,
+  anniversary: null,
+  gender: '',
+  note: '',
+  categories: [],
+  photo: null,
+  isGroup: false,
+  memberUids: [],
+  langs: [],
+  related: [],
+  xmlData: null,
+  opaqueLines: [],
+  createdAt: '2024-01-01T00:00:00Z',
+  lastModified: '2024-01-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('resolveRelatedInAddressBook', () => {
+  const contactA = MINIMAL_CONTACT({ id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' })
+  const contactB = MINIMAL_CONTACT({ id: 'f81d4fae-7dec-11d0-a765-00a0c91e6bf6', displayName: 'Bob' })
+
+  it('resolves urn:uuid to contact by ID', () => {
+    const rel: ContactRelated = {
+      value: `urn:uuid:${contactB.id}`,
+      type: 'spouse',
+      isPrimary: false,
+    }
+    const resolved = resolveRelatedInAddressBook(rel, contactA, [contactA, contactB])
+    expect(resolved).toBe(contactB)
+  })
+
+  it('handles case-insensitive UUID match (uppercase in relation)', () => {
+    const rel: ContactRelated = {
+      value: `URN:UUID:${contactB.id.toUpperCase()}`,
+      type: 'friend',
+      isPrimary: false,
+    }
+    const resolved = resolveRelatedInAddressBook(rel, contactA, [contactA, contactB])
+    expect(resolved).toBe(contactB)
+  })
+
+  it('handles case-insensitive UUID match (mixed case in both)', () => {
+    const mixedId = 'aAbBcCdD-e5F6-7890-aBcD-Ef1234567890'
+    const upperContact = MINIMAL_CONTACT({ id: mixedId.toUpperCase() })
+    const rel: ContactRelated = {
+      value: `urn:uuid:${mixedId.toLowerCase()}`,
+      type: 'co-worker',
+      isPrimary: false,
+    }
+    const resolved = resolveRelatedInAddressBook(rel, contactA, [upperContact])
+    expect(resolved).toBe(upperContact)
+  })
+
+  it('returns null for plain text value', () => {
+    const rel: ContactRelated = {
+      value: 'John Smith',
+      type: 'co-worker',
+      isPrimary: false,
+    }
+    const resolved = resolveRelatedInAddressBook(rel, contactA, [contactA, contactB])
+    expect(resolved).toBeNull()
+  })
+
+  it('returns null for unresolved UUID', () => {
+    const rel: ContactRelated = {
+      value: 'urn:uuid:00000000-0000-0000-0000-000000000000',
+      type: 'friend',
+      isPrimary: false,
+    }
+    const resolved = resolveRelatedInAddressBook(rel, contactA, [contactA, contactB])
+    expect(resolved).toBeNull()
+  })
+
+  it('returns null for HTTP URL value', () => {
+    const rel: ContactRelated = {
+      value: 'http://example.com/directory/jdoe.vcf',
+      type: 'other',
+      isPrimary: false,
+    }
+    const resolved = resolveRelatedInAddressBook(rel, contactA, [contactA, contactB])
+    expect(resolved).toBeNull()
+  })
+
+  it('filters by same address book', () => {
+    const contactC = MINIMAL_CONTACT({
+      id: '11111111-2222-3333-4444-555555555555',
+      addressBookId: 'ab-2',
+    })
+    const rel: ContactRelated = {
+      value: `urn:uuid:${contactC.id}`,
+      type: 'friend',
+      isPrimary: false,
+    }
+    // contactA is in ab-1, contactC is in ab-2 — should NOT resolve
+    const resolved = resolveRelatedInAddressBook(rel, contactA, [contactA, contactC])
+    expect(resolved).toBeNull()
+  })
+
+  it('resolves within same address book', () => {
+    const contactD = MINIMAL_CONTACT({
+      id: '22222222-3333-4444-5555-666666666666',
+      displayName: 'Diana',
+    })
+    const rel: ContactRelated = {
+      value: `urn:uuid:${contactD.id}`,
+      type: 'family',
+      isPrimary: false,
+    }
+    // Both in ab-1 (default) — should resolve
+    const resolved = resolveRelatedInAddressBook(rel, contactA, [contactA, contactD])
+    expect(resolved).toBe(contactD)
+  })
+})
+
+describe('isUrnUuid', () => {
+  it('returns true for urn:uuid format', () => {
+    expect(isUrnUuid('urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6')).toBe(true)
+  })
+
+  it('returns true for uppercase URN:UUID format', () => {
+    expect(isUrnUuid('URN:UUID:F81D4FAE-7DEC-11D0-A765-00A0C91E6BF6')).toBe(true)
+  })
+
+  it('returns false for plain text', () => {
+    expect(isUrnUuid('John Smith')).toBe(false)
+  })
+
+  it('returns false for HTTP URLs', () => {
+    expect(isUrnUuid('http://example.com/contact.vcf')).toBe(false)
+  })
+})

--- a/src/features/carddav/lib/resolveRelated.ts
+++ b/src/features/carddav/lib/resolveRelated.ts
@@ -1,0 +1,32 @@
+import type { Contact, ContactRelated } from '../types'
+
+const URN_UUID_RE = /^urn:uuid:(.+)$/i
+
+function normalizeUuid(uuid: string): string {
+  return uuid.toLowerCase()
+}
+
+/**
+ * Resolve a single RELATED entry to its target Contact within the same address book.
+ *
+ * Per RFC 6350 §6.6.6, the RELATED value can be a URI (typically urn:uuid:<contact-uid>)
+ * or text when VALUE=text parameter was present. UUID comparison is case-insensitive per RFC 4122 §3.
+ */
+export function resolveRelatedInAddressBook(
+  related: ContactRelated,
+  sourceContact: Pick<Contact, 'addressBookId'>,
+  allContacts: Contact[],
+): Contact | null {
+  const match = URN_UUID_RE.exec(related.value)
+  if (!match) return null
+
+  const targetUuid = normalizeUuid(match[1])
+  return allContacts.find(
+    (c) => normalizeUuid(c.id) === targetUuid && c.addressBookId === sourceContact.addressBookId,
+  ) ?? null
+}
+
+/** Check if a RELATED value is a URN UUID reference. */
+export function isUrnUuid(value: string): boolean {
+  return URN_UUID_RE.test(value)
+}


### PR DESCRIPTION
- Add resolveRelatedInAddressBook utility with same-address-book filter
- ContactDetail renders resolved relations as clickable links
- Unresolved UUIDs show dimmed broken-link indicator
- Plain text VALUE=text relations render as-is

fixes #87 