### PR TITLE
fix(android): safe-area insets on OEM WebViews (issue #95)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -229,10 +229,18 @@ jobs:
           # Only reached on a version-tag push (see the `if:` above), so this
           # is the release's one and only tag set — no `edge`/branch tags to
           # keep disjoint from anymore.
+          #
+          # `latest` and `main` are what a self-hoster's `docker pull` and
+          # every unpinned compose file resolve to, so they must only ever
+          # move to a stable release. A prerelease tag (`v0.27.0-beta.1` —
+          # anything with a SemVer hyphen) publishes under its own version
+          # tag only, and leaves the moving tags pointing at the last stable.
+          # This used to be unconditional, which meant tagging a beta shipped
+          # it to everyone running `:latest`.
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest
-            type=raw,value=main
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            type=raw,value=main,enable=${{ !contains(github.ref_name, '-') }}
             type=sha,prefix=sha-,format=short
 
       - name: Create manifest list & push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Calino will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Android: your events can now live in the device calendar too.** A new **Sync to Android Calendar** switch in Notification settings copies your CalDAV events into Android's own calendar, which means the system delivers your reminders — they arrive on time whether or not Calino has been opened recently, instead of only for events the app already knew about last time it ran. It also puts your calendar in front of everything else on the phone that reads it: home-screen calendar widgets, Wear OS, Android Auto and Assistant. The copy is one-way and read-only: Calino stays the only thing that writes to your CalDAV server, and turning the switch off removes the mirrored calendars again. Off by default, and it asks for calendar permission when you turn it on.
+
 ## [0.26.0] - 2026-08-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Calino will be documented in this file.
 ### Added
 
 - **Android: your events can now live in the device calendar too.** A new **Sync to Android Calendar** switch in Notification settings copies your CalDAV events into Android's own calendar, which means the system delivers your reminders — they arrive on time whether or not Calino has been opened recently, instead of only for events the app already knew about last time it ran. It also puts your calendar in front of everything else on the phone that reads it: home-screen calendar widgets, Wear OS, Android Auto and Assistant. The copy is one-way and read-only: Calino stays the only thing that writes to your CalDAV server, and turning the switch off removes the mirrored calendars again. Off by default, and it asks for calendar permission when you turn it on.
+- **Android: the device calendar now stays up to date on its own.** With **Sync to Android Calendar** on, Calino checks your CalDAV server for new events roughly once an hour in the background, so an event someone adds on your laptop — or an invitation that lands while your phone is in your pocket — reaches the device calendar and reminds you at the right time, without you having opened Calino since. Previously the mirror only ever held what Calino had already seen, so the reminder you most needed was the one it couldn't give you.
 
 ## [0.26.0] - 2026-08-02
 

--- a/android/CLAUDE.md
+++ b/android/CLAUDE.md
@@ -153,6 +153,39 @@ payload mapping and the content hash live in `src/lib/calendarMirror.ts`.
 - Package visibility: the `<queries>` block for `ACTION_INSERT` + `vnd.android.cursor.dir/event`
   is required on Android 11+, otherwise `hasCalendarApp()` always reports false.
 
+The reconcile itself lives in `CalendarMirrorWriter`, deliberately free of Capacitor types so
+both the plugin and the background worker below drive the same code. `DavHttp` is split out of
+`DavHttpPlugin` for the same reason.
+
+## Background sync (`HeadlessSyncWorker`)
+
+The mirror alone only solves half the problem: the OS reliably alarms whatever is in
+`CalendarContract`, but nothing puts an event created on *another* device there until Calino
+next opens. This worker is the other half — a WorkManager periodic job (hourly, network
+required), scheduled when `enableCalendarMirror` goes on and cancelled when it goes off.
+
+- **It runs the real TypeScript engine in a bare WebView.** Reimplementing CalDAV and
+  iCalendar parsing in Java would mean two engines to keep in step, against the one-codebase
+  premise. `src/headless.ts` is the entry point, built as a second Vite entry
+  (`headless.html`, see `vite.config.ts`).
+- **There is no Capacitor here, and there cannot be.** `Bridge` requires an
+  `AppCompatActivity` (check its constructor before assuming otherwise), a worker has none,
+  and Android 10+ forbids starting an activity from the background. So the worker serves the
+  page itself via `shouldInterceptRequest` and injects a plain `@JavascriptInterface`
+  (`CalinoHeadless`) exposing just DAV HTTP and the provider write. `src/lib/webFetch.ts`
+  checks for that bridge *before* `Capacitor.isNativePlatform()`, which is false on this page.
+- **The page must be served from `https://localhost`** — byte for byte the origin Capacitor
+  uses. That is the whole trick: same origin means the same `localStorage`, so the worker
+  reads the accounts, credentials and calendar visibility the app already stored. Change the
+  origin and it silently syncs nothing, because it sees no accounts.
+- **The headless page never writes `localStorage`.** The foreground app holds its own
+  in-memory zustand copy and rehydrates only at startup, so a background write would race it.
+  The provider is the only thing the worker mutates; the app re-mirrors from its own state
+  when it next opens and the two converge. There is a test pinning this.
+- Its reconcile is `partial`: authoritative only for the calendars it actually fetched, so it
+  cannot delete webcal-derived rows it never syncs. It also refuses to write an empty payload
+  — with nothing fetched, "no events" is indistinguishable from a network failure.
+
 ## Known OS-level gotchas (not code bugs)
 
 - **A mirrored calendar that "doesn't appear" is usually a display preference, not a sync
@@ -163,9 +196,24 @@ payload mapping and the content hash live in `src/lib/calendarMirror.ts`.
   `adb shell "content query --uri content://com.android.calendar/calendars --projection _id:name:visible:sync_events"`
   — if our rows are there with `visible=1`, the mirror is fine and it's the app's list.
   Same command with `/events` (`--where "calendar_id=N"`) and `/reminders` confirms the rest.
+- **WorkManager refuses to force-run periodic work before its first slot.**
+  `adb shell cmd jobscheduler run -f -n androidx.work.systemjobscheduler <pkg> <id>` reports
+  "Running job [FORCED]" and then logs *"Delaying execution … because it is being executed
+  before schedule"* — the run does not happen. To actually observe a background sync, build
+  with `DEFAULT_INTERVAL_MINUTES` at WorkManager's 15-minute floor and wait. Note the job id
+  changes every time the app re-enqueues on launch, so re-read it from `dumpsys jobscheduler`
+  rather than reusing one.
 - **OEM battery optimization** (MIUI, Oppo/Realme/Honor, etc.) can silently kill
   background alarms/notifications even when correctly scheduled via AlarmManager. Fix is
   a phone-side setting (set the app's battery/power mode to "No restrictions"), not code.
+  This bites `HeadlessSyncWorker` hardest, and the symptom is easy to misread as a code bug:
+  on the test Xiaomi, a job that cold-starts the process gets the process **frozen** before
+  `doWork()` runs, so *nothing at all* is logged — not even the first line of the method —
+  while `dumpsys jobscheduler` cheerfully reports "Running job [FORCED]". Bring the app to
+  the foreground and the frozen worker resumes from exactly where it stopped. A worker that
+  is frozen mid-pass also thaws with every elapsed timer firing at once, which is why the
+  headless DAV transport ignores abort signals (see `webFetch.ts`). If you need to observe a
+  run, keep the process warm: `adb shell svc power stayon true` plus a foreground launch.
 - A fresh install/reinstall resets Android's OS-level permission grants (e.g.
   `POST_NOTIFICATIONS`) independent of the app's own persisted settings — always check
   real permission state before relying on it, don't just trust an app setting.

--- a/android/CLAUDE.md
+++ b/android/CLAUDE.md
@@ -121,8 +121,48 @@ collide this way — but neither can upgrade over the other, which is the point.
 carrying a pre-split debug install (signed with the debug key under the plain
 `calino.malinov.ski` id) still needs that one uninstalled before a release APK will go on.
 
+## Calendar mirror (`CalendarMirrorPlugin`)
+
+One-way, read-only export of Calino's events into `CalendarContract`, behind the
+`enableCalendarMirror` setting (off by default). Driven from `src/hooks/useCalendarMirror.ts`;
+payload mapping and the content hash live in `src/lib/calendarMirror.ts`.
+
+- **Not a sync adapter.** No account authenticator, nothing flows back. We pass
+  `CALLER_IS_SYNCADAPTER=true` only because the provider restricts calendar creation and
+  the `ACCOUNT_TYPE`/`OWNER_ACCOUNT`/`CALENDAR_ACCESS_LEVEL` columns to that caller, and
+  because sync-adapter deletes actually remove rows rather than tombstoning them.
+  Calendars use `ACCOUNT_TYPE_LOCAL` with account name `Calino`.
+- **Ownership is `_SYNC_ID`.** Mirrored calendars carry the Calino calendar id, mirrored
+  events the Calino event id, and every query/delete is scoped to our own account name —
+  the plugin can't touch the user's Google or Exchange data. `SYNC_DATA1` holds a hash
+  computed in TS so reconcile skips unchanged events instead of rewriting (and re-alarming)
+  the whole mirror each sync.
+- **Reminders are the point.** `@capacitor/local-notifications` only schedules while the app
+  is alive. But the provider *stores* reminders without posting them — in AOSP the calendar
+  **app** raises the notification off the provider's broadcast. So `hasCalendarApp()` gates
+  this: only when a calendar app is present does `calendarMirrorStore` go `active`, and only
+  then does `useNotifications` stand its own scheduling down. With no calendar app the status
+  is `no-calendar-app` and Calino keeps scheduling locally. Don't remove that check — it's the
+  difference between reliable reminders and silent ones.
+- **Provider constraints worth remembering:** a recurring event must carry `DURATION` and no
+  `DTEND`; all-day events need `DTSTART` at midnight *UTC* with `EVENT_TIMEZONE` = `UTC`;
+  `ALLOWED_REMINDERS` must list `METHOD_ALERT` or some calendar apps ignore our reminder rows.
+- Detached recurrence instances are flattened — mirrored as standalone events, with their
+  `RECURRENCE-ID` added to the master's `EXDATE` — rather than using the provider's
+  `ORIGINAL_INSTANCE_TIME` exception model, which buys nothing for a read-only mirror.
+- Package visibility: the `<queries>` block for `ACTION_INSERT` + `vnd.android.cursor.dir/event`
+  is required on Android 11+, otherwise `hasCalendarApp()` always reports false.
+
 ## Known OS-level gotchas (not code bugs)
 
+- **A mirrored calendar that "doesn't appear" is usually a display preference, not a sync
+  failure.** Calendar apps keep their own "calendars to display" list, and a calendar they
+  have never seen before arrives unticked. Disabling the mirror deletes our calendars and
+  re-enabling mints new rows with fresh `_id`s, so every reset orphans that preference and
+  the calendars look missing again. Verify against the provider before debugging code:
+  `adb shell "content query --uri content://com.android.calendar/calendars --projection _id:name:visible:sync_events"`
+  — if our rows are there with `visible=1`, the mirror is fine and it's the app's list.
+  Same command with `/events` (`--where "calendar_id=N"`) and `/reminders` confirms the rest.
 - **OEM battery optimization** (MIUI, Oppo/Realme/Honor, etc.) can silently kill
   background alarms/notifications even when correctly scheduled via AlarmManager. Fix is
   a phone-side setting (set the app's battery/power mode to "No restrictions"), not code.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,7 +7,13 @@ import groovy.json.JsonSlurper
 // follow automatically.
 def appPackageJson = new JsonSlurper().parse(file('../../package.json'))
 def appVersionName = appPackageJson.version
-def (verMajor, verMinor, verPatch) = appVersionName.tokenize('.').collect { it.toInteger() }
+// versionName carries the full semver, prerelease suffix and all, so a beta
+// build says so on the About screen and in bug reports. versionCode has to be
+// a plain integer though, so the suffix is stripped before parsing: a
+// `0.27.0-beta.1` tester build and the eventual `0.27.0` share a code, which
+// is fine for sideloaded betas but means the final has to be installed over
+// the beta rather than upgrading it in place.
+def (verMajor, verMinor, verPatch) = appVersionName.split('-')[0].tokenize('.').collect { it.toInteger() }
 def appVersionCode = verMajor * 1000000 + verMinor * 1000 + verPatch
 
 def keystorePropertiesFile = rootProject.file('keystore.properties')
@@ -75,6 +81,9 @@ dependencies {
     implementation project(':capacitor-android')
     // DavHttpPlugin: HttpURLConnection can't send WebDAV verbs, OkHttp can.
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
+    // HeadlessSyncWorker: periodic background CalDAV refresh, so the calendar
+    // mirror holds events Calino never saw in the foreground.
+    implementation "androidx.work:work-runtime:$androidxWorkVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,4 +59,21 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <!-- Calendar mirror (CalendarMirrorPlugin): one-way export of CalDAV events
+         into CalendarContract, so the OS owns reminder alarms and widgets /
+         Wear OS / Android Auto can see them. Requested at runtime, only when
+         the user turns the mirror on. -->
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+
+    <!-- Package visibility (Android 11+): the mirror asks whether any calendar
+         app is installed, because the provider stores reminders but a calendar
+         app is what actually posts the notification. Without this the query
+         always comes back empty. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.INSERT" />
+            <data android:mimeType="vnd.android.cursor.dir/event" />
+        </intent>
+    </queries>
 </manifest>

--- a/android/app/src/main/java/calino/malinov/ski/CalendarMirrorPlugin.java
+++ b/android/app/src/main/java/calino/malinov/ski/CalendarMirrorPlugin.java
@@ -1,0 +1,507 @@
+package calino.malinov.ski;
+
+import android.Manifest;
+import android.content.ContentProviderOperation;
+import android.content.ContentProviderResult;
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.database.Cursor;
+import android.graphics.Color;
+import android.net.Uri;
+import android.provider.CalendarContract;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.PermissionState;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import com.getcapacitor.annotation.Permission;
+import com.getcapacitor.annotation.PermissionCallback;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Mirrors Calino's CalDAV events into Android's calendar provider, one-way and
+ * read-only, so that the OS owns reminder alarms and so the events are visible
+ * to calendar widgets, Wear OS, Android Auto and anything else reading
+ * {@link CalendarContract}.
+ *
+ * <p>The mirror is deliberately <em>not</em> a sync adapter: there is no account
+ * authenticator and nothing ever flows back. We write with
+ * {@code CALLER_IS_SYNCADAPTER=true} purely because the provider only allows
+ * that caller to create calendars and to set the columns we need
+ * (ACCOUNT_TYPE, OWNER_ACCOUNT, CALENDAR_ACCESS_LEVEL). The calendars use
+ * {@link CalendarContract#ACCOUNT_TYPE_LOCAL}, the documented account type for
+ * device-local calendars that no sync adapter owns.
+ *
+ * <p>Ownership is tracked entirely through {@code _SYNC_ID}: a mirrored calendar
+ * carries Calino's calendar id, a mirrored event carries Calino's event id. We
+ * only ever read, update or delete rows inside calendars we created under our
+ * own account name, so a bug here cannot touch the user's Google or Exchange
+ * data.
+ *
+ * <p>{@code SYNC_DATA1} holds a content hash computed on the JS side (see
+ * {@code src/lib/calendarMirror.ts}) so reconcile can skip unchanged events
+ * instead of rewriting the whole mirror on every sync — rewriting churns the
+ * provider's alarm scheduling for events that did not change.
+ */
+@CapacitorPlugin(
+    name = "CalendarMirror",
+    permissions = {
+        @Permission(
+            alias = CalendarMirrorPlugin.CALENDAR_PERMISSION,
+            strings = { Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR }
+        )
+    }
+)
+public class CalendarMirrorPlugin extends Plugin {
+    static final String CALENDAR_PERMISSION = "calendar";
+
+    /** Account name for every calendar we create. Also our ownership marker. */
+    private static final String ACCOUNT_NAME = "Calino";
+
+    /**
+     * The provider rejects oversized transactions, and a first sync can produce
+     * thousands of operations, so batches are chunked. Each event contributes
+     * one insert plus one op per reminder, so this stays well under the limit.
+     */
+    private static final int BATCH_SIZE = 400;
+
+    private static final String[] CALENDAR_PROJECTION = {
+        CalendarContract.Calendars._ID,
+        CalendarContract.Calendars._SYNC_ID,
+        CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+        CalendarContract.Calendars.CALENDAR_COLOR,
+    };
+
+    private static final String[] EVENT_PROJECTION = {
+        CalendarContract.Events._ID,
+        CalendarContract.Events._SYNC_ID,
+        CalendarContract.Events.SYNC_DATA1,
+        CalendarContract.Events.CALENDAR_ID,
+    };
+
+    // ---------------------------------------------------------------- permissions
+
+    @PluginMethod
+    public void checkCalendarPermission(PluginCall call) {
+        JSObject result = new JSObject();
+        result.put("granted", getPermissionState(CALENDAR_PERMISSION) == PermissionState.GRANTED);
+        call.resolve(result);
+    }
+
+    @PluginMethod
+    public void requestCalendarPermission(PluginCall call) {
+        if (getPermissionState(CALENDAR_PERMISSION) == PermissionState.GRANTED) {
+            JSObject result = new JSObject();
+            result.put("granted", true);
+            call.resolve(result);
+            return;
+        }
+        requestPermissionForAlias(CALENDAR_PERMISSION, call, "calendarPermissionCallback");
+    }
+
+    @PermissionCallback
+    private void calendarPermissionCallback(PluginCall call) {
+        JSObject result = new JSObject();
+        result.put("granted", getPermissionState(CALENDAR_PERMISSION) == PermissionState.GRANTED);
+        call.resolve(result);
+    }
+
+    /**
+     * Whether any installed app can present calendar events.
+     *
+     * <p>This matters because the provider stores reminders but does not post
+     * notifications for them: in AOSP it is the calendar <em>app</em> that
+     * receives the provider's reminder broadcast and raises the notification.
+     * On a device with no calendar app, handing reminders to the provider would
+     * silently drop them, so the JS side keeps its own {@code LocalNotifications}
+     * scheduling when this returns false.
+     */
+    @PluginMethod
+    public void hasCalendarApp(PluginCall call) {
+        Intent intent = new Intent(Intent.ACTION_INSERT).setData(CalendarContract.Events.CONTENT_URI);
+        List<?> handlers = getContext()
+            .getPackageManager()
+            .queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
+        JSObject result = new JSObject();
+        result.put("present", !handlers.isEmpty());
+        call.resolve(result);
+    }
+
+    // ---------------------------------------------------------------- sync
+
+    /**
+     * Reconciles the mirror against the given calendars and events. Both lists
+     * are the complete desired state — anything of ours not present is removed.
+     */
+    @PluginMethod
+    public void sync(PluginCall call) {
+        if (getPermissionState(CALENDAR_PERMISSION) != PermissionState.GRANTED) {
+            call.reject("Calendar permission not granted");
+            return;
+        }
+
+        JSArray calendarsInput = call.getArray("calendars");
+        JSArray eventsInput = call.getArray("events");
+        if (calendarsInput == null || eventsInput == null) {
+            call.reject("sync() requires 'calendars' and 'events'");
+            return;
+        }
+
+        try {
+            Map<String, Long> calendarIds = reconcileCalendars(calendarsInput);
+            int[] counts = reconcileEvents(eventsInput, calendarIds);
+
+            JSObject result = new JSObject();
+            result.put("calendars", calendarIds.size());
+            result.put("written", counts[0]);
+            result.put("removed", counts[1]);
+            call.resolve(result);
+        } catch (Exception e) {
+            call.reject("Calendar mirror sync failed: " + e.getMessage(), e);
+        }
+    }
+
+    /** Removes every calendar (and thus every event) the mirror created. */
+    @PluginMethod
+    public void clear(PluginCall call) {
+        if (getPermissionState(CALENDAR_PERMISSION) != PermissionState.GRANTED) {
+            // Nothing we could have written without the permission, so this is
+            // a success, not an error — it keeps "turn the setting off" simple
+            // on the JS side.
+            call.resolve();
+            return;
+        }
+        try {
+            int removed = getContext()
+                .getContentResolver()
+                .delete(syncAdapterUri(CalendarContract.Calendars.CONTENT_URI), ownCalendarSelection(), null);
+            JSObject result = new JSObject();
+            result.put("removed", removed);
+            call.resolve(result);
+        } catch (Exception e) {
+            call.reject("Calendar mirror clear failed: " + e.getMessage(), e);
+        }
+    }
+
+    // ---------------------------------------------------------------- calendars
+
+    /**
+     * Creates, updates and deletes mirrored calendars so they match the input.
+     *
+     * @return Calino calendar id → provider calendar row id, for the event pass.
+     */
+    private Map<String, Long> reconcileCalendars(JSArray input) throws Exception {
+        Map<String, JSONObject> desired = new HashMap<>();
+        for (int i = 0; i < input.length(); i++) {
+            JSONObject calendar = input.getJSONObject(i);
+            desired.put(calendar.getString("id"), calendar);
+        }
+
+        Map<String, Long> resolved = new HashMap<>();
+        ContentResolver resolver = getContext().getContentResolver();
+
+        try (Cursor cursor = resolver.query(
+            syncAdapterUri(CalendarContract.Calendars.CONTENT_URI),
+            CALENDAR_PROJECTION,
+            ownCalendarSelection(),
+            null,
+            null
+        )) {
+            while (cursor != null && cursor.moveToNext()) {
+                long rowId = cursor.getLong(0);
+                String syncId = cursor.getString(1);
+                JSONObject wanted = syncId == null ? null : desired.get(syncId);
+
+                if (wanted == null) {
+                    resolver.delete(
+                        ContentUris.withAppendedId(
+                            syncAdapterUri(CalendarContract.Calendars.CONTENT_URI),
+                            rowId
+                        ),
+                        null,
+                        null
+                    );
+                    continue;
+                }
+
+                // Name and colour are the only mutable fields; rewrite them
+                // only when they actually drifted.
+                String name = wanted.getString("name");
+                int color = parseColor(wanted.optString("color", null));
+                if (!name.equals(cursor.getString(2)) || color != cursor.getInt(3)) {
+                    ContentValues values = new ContentValues();
+                    values.put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, name);
+                    values.put(CalendarContract.Calendars.NAME, name);
+                    values.put(CalendarContract.Calendars.CALENDAR_COLOR, color);
+                    resolver.update(
+                        ContentUris.withAppendedId(
+                            syncAdapterUri(CalendarContract.Calendars.CONTENT_URI),
+                            rowId
+                        ),
+                        values,
+                        null,
+                        null
+                    );
+                }
+
+                resolved.put(syncId, rowId);
+            }
+        }
+
+        for (Map.Entry<String, JSONObject> entry : desired.entrySet()) {
+            if (resolved.containsKey(entry.getKey())) continue;
+            resolved.put(entry.getKey(), insertCalendar(entry.getKey(), entry.getValue()));
+        }
+
+        return resolved;
+    }
+
+    private long insertCalendar(String calinoId, JSONObject calendar) throws Exception {
+        String name = calendar.getString("name");
+
+        ContentValues values = new ContentValues();
+        values.put(CalendarContract.Calendars._SYNC_ID, calinoId);
+        values.put(CalendarContract.Calendars.ACCOUNT_NAME, ACCOUNT_NAME);
+        values.put(CalendarContract.Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL);
+        values.put(CalendarContract.Calendars.OWNER_ACCOUNT, ACCOUNT_NAME);
+        values.put(CalendarContract.Calendars.NAME, name);
+        values.put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, name);
+        values.put(CalendarContract.Calendars.CALENDAR_COLOR, parseColor(calendar.optString("color", null)));
+        // Read-only: Calino stays the single writer, and calendar apps will not
+        // offer to edit events they cannot push back to the CalDAV server.
+        values.put(
+            CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
+            CalendarContract.Calendars.CAL_ACCESS_READ
+        );
+        values.put(CalendarContract.Calendars.VISIBLE, 1);
+        values.put(CalendarContract.Calendars.SYNC_EVENTS, 1);
+        values.put(CalendarContract.Calendars.CALENDAR_TIME_ZONE, java.util.TimeZone.getDefault().getID());
+        // Without an explicit allow-list some calendar apps refuse to surface
+        // our reminder rows at all.
+        values.put(
+            CalendarContract.Calendars.ALLOWED_REMINDERS,
+            String.valueOf(CalendarContract.Reminders.METHOD_ALERT)
+        );
+        values.put(CalendarContract.Calendars.ALLOWED_AVAILABILITY, "0,1");
+        values.put(CalendarContract.Calendars.ALLOWED_ATTENDEE_TYPES, "0,1,2");
+
+        Uri inserted = getContext()
+            .getContentResolver()
+            .insert(syncAdapterUri(CalendarContract.Calendars.CONTENT_URI), values);
+        if (inserted == null) throw new IllegalStateException("Could not create calendar '" + name + "'");
+        return ContentUris.parseId(inserted);
+    }
+
+    // ---------------------------------------------------------------- events
+
+    /** @return {written, removed} */
+    private int[] reconcileEvents(JSArray input, Map<String, Long> calendarIds) throws Exception {
+        Map<String, JSONObject> desired = new HashMap<>();
+        for (int i = 0; i < input.length(); i++) {
+            JSONObject event = input.getJSONObject(i);
+            // An event in a calendar we did not mirror has nowhere to go.
+            if (calendarIds.containsKey(event.getString("calendarId"))) {
+                desired.put(event.getString("id"), event);
+            }
+        }
+
+        if (calendarIds.isEmpty()) return new int[] { 0, 0 };
+
+        List<ContentProviderOperation> ops = new ArrayList<>();
+        Set<String> upToDate = new HashSet<>();
+        int removed = 0;
+
+        Uri eventsUri = syncAdapterUri(CalendarContract.Events.CONTENT_URI);
+        try (Cursor cursor = getContext().getContentResolver().query(
+            eventsUri,
+            EVENT_PROJECTION,
+            CalendarContract.Events.CALENDAR_ID + " IN (" + joinIds(calendarIds.values()) + ")",
+            null,
+            null
+        )) {
+            while (cursor != null && cursor.moveToNext()) {
+                long rowId = cursor.getLong(0);
+                String syncId = cursor.getString(1);
+                String hash = cursor.getString(2);
+                long calendarRowId = cursor.getLong(3);
+
+                JSONObject wanted = syncId == null ? null : desired.get(syncId);
+                Long wantedCalendar = wanted == null
+                    ? null
+                    : calendarIds.get(wanted.getString("calendarId"));
+
+                boolean unchanged = wanted != null
+                    && wantedCalendar != null
+                    && wantedCalendar == calendarRowId
+                    && wanted.getString("hash").equals(hash);
+
+                if (unchanged) {
+                    upToDate.add(syncId);
+                    continue;
+                }
+
+                // Changed events are deleted and re-inserted rather than
+                // updated: the reminder rows hang off the event id and would
+                // otherwise need their own diff for no practical gain.
+                ops.add(
+                    ContentProviderOperation
+                        .newDelete(ContentUris.withAppendedId(eventsUri, rowId))
+                        .build()
+                );
+                if (wanted == null) removed++;
+            }
+        }
+
+        int written = 0;
+        for (Map.Entry<String, JSONObject> entry : desired.entrySet()) {
+            if (upToDate.contains(entry.getKey())) continue;
+            appendEventInsert(ops, entry.getKey(), entry.getValue(), calendarIds);
+            written++;
+            if (ops.size() >= BATCH_SIZE) flush(ops);
+        }
+        flush(ops);
+
+        return new int[] { written, removed };
+    }
+
+    private void appendEventInsert(
+        List<ContentProviderOperation> ops,
+        String calinoId,
+        JSONObject event,
+        Map<String, Long> calendarIds
+    ) throws Exception {
+        int eventOpIndex = ops.size();
+
+        ContentProviderOperation.Builder builder = ContentProviderOperation
+            .newInsert(syncAdapterUri(CalendarContract.Events.CONTENT_URI))
+            .withValue(CalendarContract.Events._SYNC_ID, calinoId)
+            .withValue(CalendarContract.Events.SYNC_DATA1, event.getString("hash"))
+            .withValue(CalendarContract.Events.DIRTY, 0)
+            .withValue(
+                CalendarContract.Events.CALENDAR_ID,
+                calendarIds.get(event.getString("calendarId"))
+            )
+            .withValue(CalendarContract.Events.TITLE, event.optString("title", ""))
+            .withValue(CalendarContract.Events.DTSTART, event.getLong("start"))
+            .withValue(CalendarContract.Events.ALL_DAY, event.optBoolean("allDay", false) ? 1 : 0)
+            .withValue(CalendarContract.Events.EVENT_TIMEZONE, event.getString("timezone"))
+            .withValue(
+                CalendarContract.Events.ACCESS_LEVEL,
+                CalendarContract.Events.ACCESS_DEFAULT
+            );
+
+        String description = event.optString("description", null);
+        if (description != null && !description.isEmpty()) {
+            builder.withValue(CalendarContract.Events.DESCRIPTION, description);
+        }
+        String location = event.optString("location", null);
+        if (location != null && !location.isEmpty()) {
+            builder.withValue(CalendarContract.Events.EVENT_LOCATION, location);
+        }
+
+        builder.withValue(
+            CalendarContract.Events.AVAILABILITY,
+            "transparent".equals(event.optString("transparency", null))
+                ? CalendarContract.Events.AVAILABILITY_FREE
+                : CalendarContract.Events.AVAILABILITY_BUSY
+        );
+
+        String rrule = event.optString("rrule", null);
+        if (rrule != null && !rrule.isEmpty()) {
+            // The provider requires recurring events to carry DURATION and to
+            // leave DTEND null; setting both is rejected.
+            builder.withValue(CalendarContract.Events.RRULE, rrule);
+            builder.withValue(CalendarContract.Events.DURATION, event.getString("duration"));
+            String exdate = event.optString("exdate", null);
+            if (exdate != null && !exdate.isEmpty()) {
+                builder.withValue(CalendarContract.Events.EXDATE, exdate);
+            }
+        } else {
+            builder.withValue(CalendarContract.Events.DTEND, event.getLong("end"));
+        }
+
+        JSONArray reminders = event.optJSONArray("reminders");
+        int reminderCount = reminders == null ? 0 : reminders.length();
+        builder.withValue(CalendarContract.Events.HAS_ALARM, reminderCount > 0 ? 1 : 0);
+        ops.add(builder.build());
+
+        for (int i = 0; i < reminderCount; i++) {
+            ops.add(
+                ContentProviderOperation
+                    .newInsert(syncAdapterUri(CalendarContract.Reminders.CONTENT_URI))
+                    // Back-reference: the event row id does not exist until the
+                    // batch is applied.
+                    .withValueBackReference(CalendarContract.Reminders.EVENT_ID, eventOpIndex)
+                    .withValue(CalendarContract.Reminders.MINUTES, reminders.getInt(i))
+                    .withValue(CalendarContract.Reminders.METHOD, CalendarContract.Reminders.METHOD_ALERT)
+                    .build()
+            );
+        }
+    }
+
+    private void flush(List<ContentProviderOperation> ops) throws Exception {
+        if (ops.isEmpty()) return;
+        ContentProviderResult[] results = getContext()
+            .getContentResolver()
+            .applyBatch(CalendarContract.AUTHORITY, new ArrayList<>(ops));
+        if (results.length != ops.size()) {
+            throw new IllegalStateException(
+                "Calendar provider applied " + results.length + " of " + ops.size() + " operations"
+            );
+        }
+        ops.clear();
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /**
+     * Tags a URI as a sync-adapter call. Required to create calendars, to set
+     * the sync columns we key ownership off, and so deletes actually remove
+     * rows instead of tombstoning them as {@code DELETED=1}.
+     */
+    private static Uri syncAdapterUri(Uri uri) {
+        return uri
+            .buildUpon()
+            .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
+            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, ACCOUNT_NAME)
+            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL)
+            .build();
+    }
+
+    /** Restricts every query and delete to calendars this plugin created. */
+    private static String ownCalendarSelection() {
+        return CalendarContract.Calendars.ACCOUNT_NAME + " = '" + ACCOUNT_NAME + "' AND "
+            + CalendarContract.Calendars.ACCOUNT_TYPE + " = '" + CalendarContract.ACCOUNT_TYPE_LOCAL + "'";
+    }
+
+    private static String joinIds(Iterable<Long> ids) {
+        StringBuilder joined = new StringBuilder();
+        for (Long id : ids) {
+            if (joined.length() > 0) joined.append(',');
+            joined.append(id);
+        }
+        return joined.toString();
+    }
+
+    private static int parseColor(String hex) {
+        if (hex == null || hex.isEmpty()) return Color.GRAY;
+        try {
+            return Color.parseColor(hex);
+        } catch (IllegalArgumentException e) {
+            return Color.GRAY;
+        }
+    }
+}

--- a/android/app/src/main/java/calino/malinov/ski/CalendarMirrorPlugin.java
+++ b/android/app/src/main/java/calino/malinov/ski/CalendarMirrorPlugin.java
@@ -1,18 +1,9 @@
 package calino.malinov.ski;
 
 import android.Manifest;
-import android.content.ContentProviderOperation;
-import android.content.ContentProviderResult;
-import android.content.ContentResolver;
-import android.content.ContentUris;
-import android.content.ContentValues;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.database.Cursor;
-import android.graphics.Color;
-import android.net.Uri;
 import android.provider.CalendarContract;
-import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -21,39 +12,16 @@ import com.getcapacitor.PermissionState;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 /**
- * Mirrors Calino's CalDAV events into Android's calendar provider, one-way and
- * read-only, so that the OS owns reminder alarms and so the events are visible
- * to calendar widgets, Wear OS, Android Auto and anything else reading
- * {@link CalendarContract}.
+ * Capacitor bridge for the calendar mirror. The reconcile itself lives in
+ * {@link CalendarMirrorWriter}, shared with {@link HeadlessSyncWorker}; this
+ * class only handles permissions, the bridge plumbing, and scheduling the
+ * background refresh.
  *
- * <p>The mirror is deliberately <em>not</em> a sync adapter: there is no account
- * authenticator and nothing ever flows back. We write with
- * {@code CALLER_IS_SYNCADAPTER=true} purely because the provider only allows
- * that caller to create calendars and to set the columns we need
- * (ACCOUNT_TYPE, OWNER_ACCOUNT, CALENDAR_ACCESS_LEVEL). The calendars use
- * {@link CalendarContract#ACCOUNT_TYPE_LOCAL}, the documented account type for
- * device-local calendars that no sync adapter owns.
- *
- * <p>Ownership is tracked entirely through {@code _SYNC_ID}: a mirrored calendar
- * carries Calino's calendar id, a mirrored event carries Calino's event id. We
- * only ever read, update or delete rows inside calendars we created under our
- * own account name, so a bug here cannot touch the user's Google or Exchange
- * data.
- *
- * <p>{@code SYNC_DATA1} holds a content hash computed on the JS side (see
- * {@code src/lib/calendarMirror.ts}) so reconcile can skip unchanged events
- * instead of rewriting the whole mirror on every sync — rewriting churns the
- * provider's alarm scheduling for events that did not change.
+ * <p>See {@code src/lib/calendarMirror.ts} for the JS side and
+ * {@code android/CLAUDE.md} for why the mirror is not a sync adapter.
  */
 @CapacitorPlugin(
     name = "CalendarMirror",
@@ -66,30 +34,6 @@ import org.json.JSONObject;
 )
 public class CalendarMirrorPlugin extends Plugin {
     static final String CALENDAR_PERMISSION = "calendar";
-
-    /** Account name for every calendar we create. Also our ownership marker. */
-    private static final String ACCOUNT_NAME = "Calino";
-
-    /**
-     * The provider rejects oversized transactions, and a first sync can produce
-     * thousands of operations, so batches are chunked. Each event contributes
-     * one insert plus one op per reminder, so this stays well under the limit.
-     */
-    private static final int BATCH_SIZE = 400;
-
-    private static final String[] CALENDAR_PROJECTION = {
-        CalendarContract.Calendars._ID,
-        CalendarContract.Calendars._SYNC_ID,
-        CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
-        CalendarContract.Calendars.CALENDAR_COLOR,
-    };
-
-    private static final String[] EVENT_PROJECTION = {
-        CalendarContract.Events._ID,
-        CalendarContract.Events._SYNC_ID,
-        CalendarContract.Events.SYNC_DATA1,
-        CalendarContract.Events.CALENDAR_ID,
-    };
 
     // ---------------------------------------------------------------- permissions
 
@@ -153,22 +97,15 @@ public class CalendarMirrorPlugin extends Plugin {
             return;
         }
 
-        JSArray calendarsInput = call.getArray("calendars");
-        JSArray eventsInput = call.getArray("events");
-        if (calendarsInput == null || eventsInput == null) {
+        if (call.getArray("calendars") == null || call.getArray("events") == null) {
             call.reject("sync() requires 'calendars' and 'events'");
             return;
         }
 
         try {
-            Map<String, Long> calendarIds = reconcileCalendars(calendarsInput);
-            int[] counts = reconcileEvents(eventsInput, calendarIds);
-
-            JSObject result = new JSObject();
-            result.put("calendars", calendarIds.size());
-            result.put("written", counts[0]);
-            result.put("removed", counts[1]);
-            call.resolve(result);
+            CalendarMirrorWriter.Result result = new CalendarMirrorWriter(getContext())
+                .sync(call.getArray("calendars"), call.getArray("events"), false);
+            call.resolve(JSObject.fromJSONObject(result.toJson()));
         } catch (Exception e) {
             call.reject("Calendar mirror sync failed: " + e.getMessage(), e);
         }
@@ -185,323 +122,42 @@ public class CalendarMirrorPlugin extends Plugin {
             return;
         }
         try {
-            int removed = getContext()
-                .getContentResolver()
-                .delete(syncAdapterUri(CalendarContract.Calendars.CONTENT_URI), ownCalendarSelection(), null);
             JSObject result = new JSObject();
-            result.put("removed", removed);
+            result.put("removed", new CalendarMirrorWriter(getContext()).clear());
             call.resolve(result);
         } catch (Exception e) {
             call.reject("Calendar mirror clear failed: " + e.getMessage(), e);
         }
     }
 
-    // ---------------------------------------------------------------- calendars
+    // ---------------------------------------------------------------- background
 
     /**
-     * Creates, updates and deletes mirrored calendars so they match the input.
-     *
-     * @return Calino calendar id → provider calendar row id, for the event pass.
+     * Starts the periodic background refresh. Without it the mirror only ever
+     * holds what Calino knew the last time it was open, so an event created on
+     * another device never alarms — see {@link HeadlessSyncWorker}.
      */
-    private Map<String, Long> reconcileCalendars(JSArray input) throws Exception {
-        Map<String, JSONObject> desired = new HashMap<>();
-        for (int i = 0; i < input.length(); i++) {
-            JSONObject calendar = input.getJSONObject(i);
-            desired.put(calendar.getString("id"), calendar);
-        }
-
-        Map<String, Long> resolved = new HashMap<>();
-        ContentResolver resolver = getContext().getContentResolver();
-
-        try (Cursor cursor = resolver.query(
-            syncAdapterUri(CalendarContract.Calendars.CONTENT_URI),
-            CALENDAR_PROJECTION,
-            ownCalendarSelection(),
-            null,
-            null
-        )) {
-            while (cursor != null && cursor.moveToNext()) {
-                long rowId = cursor.getLong(0);
-                String syncId = cursor.getString(1);
-                JSONObject wanted = syncId == null ? null : desired.get(syncId);
-
-                if (wanted == null) {
-                    resolver.delete(
-                        ContentUris.withAppendedId(
-                            syncAdapterUri(CalendarContract.Calendars.CONTENT_URI),
-                            rowId
-                        ),
-                        null,
-                        null
-                    );
-                    continue;
-                }
-
-                // Name and colour are the only mutable fields; rewrite them
-                // only when they actually drifted.
-                String name = wanted.getString("name");
-                int color = parseColor(wanted.optString("color", null));
-                if (!name.equals(cursor.getString(2)) || color != cursor.getInt(3)) {
-                    ContentValues values = new ContentValues();
-                    values.put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, name);
-                    values.put(CalendarContract.Calendars.NAME, name);
-                    values.put(CalendarContract.Calendars.CALENDAR_COLOR, color);
-                    resolver.update(
-                        ContentUris.withAppendedId(
-                            syncAdapterUri(CalendarContract.Calendars.CONTENT_URI),
-                            rowId
-                        ),
-                        values,
-                        null,
-                        null
-                    );
-                }
-
-                resolved.put(syncId, rowId);
-            }
-        }
-
-        for (Map.Entry<String, JSONObject> entry : desired.entrySet()) {
-            if (resolved.containsKey(entry.getKey())) continue;
-            resolved.put(entry.getKey(), insertCalendar(entry.getKey(), entry.getValue()));
-        }
-
-        return resolved;
-    }
-
-    private long insertCalendar(String calinoId, JSONObject calendar) throws Exception {
-        String name = calendar.getString("name");
-
-        ContentValues values = new ContentValues();
-        values.put(CalendarContract.Calendars._SYNC_ID, calinoId);
-        values.put(CalendarContract.Calendars.ACCOUNT_NAME, ACCOUNT_NAME);
-        values.put(CalendarContract.Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL);
-        values.put(CalendarContract.Calendars.OWNER_ACCOUNT, ACCOUNT_NAME);
-        values.put(CalendarContract.Calendars.NAME, name);
-        values.put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, name);
-        values.put(CalendarContract.Calendars.CALENDAR_COLOR, parseColor(calendar.optString("color", null)));
-        // Read-only: Calino stays the single writer, and calendar apps will not
-        // offer to edit events they cannot push back to the CalDAV server.
-        values.put(
-            CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
-            CalendarContract.Calendars.CAL_ACCESS_READ
-        );
-        values.put(CalendarContract.Calendars.VISIBLE, 1);
-        values.put(CalendarContract.Calendars.SYNC_EVENTS, 1);
-        values.put(CalendarContract.Calendars.CALENDAR_TIME_ZONE, java.util.TimeZone.getDefault().getID());
-        // Without an explicit allow-list some calendar apps refuse to surface
-        // our reminder rows at all.
-        values.put(
-            CalendarContract.Calendars.ALLOWED_REMINDERS,
-            String.valueOf(CalendarContract.Reminders.METHOD_ALERT)
-        );
-        values.put(CalendarContract.Calendars.ALLOWED_AVAILABILITY, "0,1");
-        values.put(CalendarContract.Calendars.ALLOWED_ATTENDEE_TYPES, "0,1,2");
-
-        Uri inserted = getContext()
-            .getContentResolver()
-            .insert(syncAdapterUri(CalendarContract.Calendars.CONTENT_URI), values);
-        if (inserted == null) throw new IllegalStateException("Could not create calendar '" + name + "'");
-        return ContentUris.parseId(inserted);
-    }
-
-    // ---------------------------------------------------------------- events
-
-    /** @return {written, removed} */
-    private int[] reconcileEvents(JSArray input, Map<String, Long> calendarIds) throws Exception {
-        Map<String, JSONObject> desired = new HashMap<>();
-        for (int i = 0; i < input.length(); i++) {
-            JSONObject event = input.getJSONObject(i);
-            // An event in a calendar we did not mirror has nowhere to go.
-            if (calendarIds.containsKey(event.getString("calendarId"))) {
-                desired.put(event.getString("id"), event);
-            }
-        }
-
-        if (calendarIds.isEmpty()) return new int[] { 0, 0 };
-
-        List<ContentProviderOperation> ops = new ArrayList<>();
-        Set<String> upToDate = new HashSet<>();
-        int removed = 0;
-
-        Uri eventsUri = syncAdapterUri(CalendarContract.Events.CONTENT_URI);
-        try (Cursor cursor = getContext().getContentResolver().query(
-            eventsUri,
-            EVENT_PROJECTION,
-            CalendarContract.Events.CALENDAR_ID + " IN (" + joinIds(calendarIds.values()) + ")",
-            null,
-            null
-        )) {
-            while (cursor != null && cursor.moveToNext()) {
-                long rowId = cursor.getLong(0);
-                String syncId = cursor.getString(1);
-                String hash = cursor.getString(2);
-                long calendarRowId = cursor.getLong(3);
-
-                JSONObject wanted = syncId == null ? null : desired.get(syncId);
-                Long wantedCalendar = wanted == null
-                    ? null
-                    : calendarIds.get(wanted.getString("calendarId"));
-
-                boolean unchanged = wanted != null
-                    && wantedCalendar != null
-                    && wantedCalendar == calendarRowId
-                    && wanted.getString("hash").equals(hash);
-
-                if (unchanged) {
-                    upToDate.add(syncId);
-                    continue;
-                }
-
-                // Changed events are deleted and re-inserted rather than
-                // updated: the reminder rows hang off the event id and would
-                // otherwise need their own diff for no practical gain.
-                ops.add(
-                    ContentProviderOperation
-                        .newDelete(ContentUris.withAppendedId(eventsUri, rowId))
-                        .build()
-                );
-                if (wanted == null) removed++;
-            }
-        }
-
-        int written = 0;
-        for (Map.Entry<String, JSONObject> entry : desired.entrySet()) {
-            if (upToDate.contains(entry.getKey())) continue;
-            appendEventInsert(ops, entry.getKey(), entry.getValue(), calendarIds);
-            written++;
-            if (ops.size() >= BATCH_SIZE) flush(ops);
-        }
-        flush(ops);
-
-        return new int[] { written, removed };
-    }
-
-    private void appendEventInsert(
-        List<ContentProviderOperation> ops,
-        String calinoId,
-        JSONObject event,
-        Map<String, Long> calendarIds
-    ) throws Exception {
-        int eventOpIndex = ops.size();
-
-        ContentProviderOperation.Builder builder = ContentProviderOperation
-            .newInsert(syncAdapterUri(CalendarContract.Events.CONTENT_URI))
-            .withValue(CalendarContract.Events._SYNC_ID, calinoId)
-            .withValue(CalendarContract.Events.SYNC_DATA1, event.getString("hash"))
-            .withValue(CalendarContract.Events.DIRTY, 0)
-            .withValue(
-                CalendarContract.Events.CALENDAR_ID,
-                calendarIds.get(event.getString("calendarId"))
-            )
-            .withValue(CalendarContract.Events.TITLE, event.optString("title", ""))
-            .withValue(CalendarContract.Events.DTSTART, event.getLong("start"))
-            .withValue(CalendarContract.Events.ALL_DAY, event.optBoolean("allDay", false) ? 1 : 0)
-            .withValue(CalendarContract.Events.EVENT_TIMEZONE, event.getString("timezone"))
-            .withValue(
-                CalendarContract.Events.ACCESS_LEVEL,
-                CalendarContract.Events.ACCESS_DEFAULT
-            );
-
-        String description = event.optString("description", null);
-        if (description != null && !description.isEmpty()) {
-            builder.withValue(CalendarContract.Events.DESCRIPTION, description);
-        }
-        String location = event.optString("location", null);
-        if (location != null && !location.isEmpty()) {
-            builder.withValue(CalendarContract.Events.EVENT_LOCATION, location);
-        }
-
-        builder.withValue(
-            CalendarContract.Events.AVAILABILITY,
-            "transparent".equals(event.optString("transparency", null))
-                ? CalendarContract.Events.AVAILABILITY_FREE
-                : CalendarContract.Events.AVAILABILITY_BUSY
-        );
-
-        String rrule = event.optString("rrule", null);
-        if (rrule != null && !rrule.isEmpty()) {
-            // The provider requires recurring events to carry DURATION and to
-            // leave DTEND null; setting both is rejected.
-            builder.withValue(CalendarContract.Events.RRULE, rrule);
-            builder.withValue(CalendarContract.Events.DURATION, event.getString("duration"));
-            String exdate = event.optString("exdate", null);
-            if (exdate != null && !exdate.isEmpty()) {
-                builder.withValue(CalendarContract.Events.EXDATE, exdate);
-            }
-        } else {
-            builder.withValue(CalendarContract.Events.DTEND, event.getLong("end"));
-        }
-
-        JSONArray reminders = event.optJSONArray("reminders");
-        int reminderCount = reminders == null ? 0 : reminders.length();
-        builder.withValue(CalendarContract.Events.HAS_ALARM, reminderCount > 0 ? 1 : 0);
-        ops.add(builder.build());
-
-        for (int i = 0; i < reminderCount; i++) {
-            ops.add(
-                ContentProviderOperation
-                    .newInsert(syncAdapterUri(CalendarContract.Reminders.CONTENT_URI))
-                    // Back-reference: the event row id does not exist until the
-                    // batch is applied.
-                    .withValueBackReference(CalendarContract.Reminders.EVENT_ID, eventOpIndex)
-                    .withValue(CalendarContract.Reminders.MINUTES, reminders.getInt(i))
-                    .withValue(CalendarContract.Reminders.METHOD, CalendarContract.Reminders.METHOD_ALERT)
-                    .build()
-            );
-        }
-    }
-
-    private void flush(List<ContentProviderOperation> ops) throws Exception {
-        if (ops.isEmpty()) return;
-        ContentProviderResult[] results = getContext()
-            .getContentResolver()
-            .applyBatch(CalendarContract.AUTHORITY, new ArrayList<>(ops));
-        if (results.length != ops.size()) {
-            throw new IllegalStateException(
-                "Calendar provider applied " + results.length + " of " + ops.size() + " operations"
-            );
-        }
-        ops.clear();
-    }
-
-    // ---------------------------------------------------------------- helpers
-
-    /**
-     * Tags a URI as a sync-adapter call. Required to create calendars, to set
-     * the sync columns we key ownership off, and so deletes actually remove
-     * rows instead of tombstoning them as {@code DELETED=1}.
-     */
-    private static Uri syncAdapterUri(Uri uri) {
-        return uri
-            .buildUpon()
-            .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
-            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, ACCOUNT_NAME)
-            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL)
-            .build();
-    }
-
-    /** Restricts every query and delete to calendars this plugin created. */
-    private static String ownCalendarSelection() {
-        return CalendarContract.Calendars.ACCOUNT_NAME + " = '" + ACCOUNT_NAME + "' AND "
-            + CalendarContract.Calendars.ACCOUNT_TYPE + " = '" + CalendarContract.ACCOUNT_TYPE_LOCAL + "'";
-    }
-
-    private static String joinIds(Iterable<Long> ids) {
-        StringBuilder joined = new StringBuilder();
-        for (Long id : ids) {
-            if (joined.length() > 0) joined.append(',');
-            joined.append(id);
-        }
-        return joined.toString();
-    }
-
-    private static int parseColor(String hex) {
-        if (hex == null || hex.isEmpty()) return Color.GRAY;
+    @PluginMethod
+    public void scheduleBackgroundSync(PluginCall call) {
         try {
-            return Color.parseColor(hex);
-        } catch (IllegalArgumentException e) {
-            return Color.GRAY;
+            Integer requested = call.getInt("intervalMinutes");
+            long minutes = requested == null || requested <= 0
+                ? HeadlessSyncWorker.DEFAULT_INTERVAL_MINUTES
+                : requested;
+            HeadlessSyncWorker.schedule(getContext(), minutes);
+            call.resolve();
+        } catch (Exception e) {
+            call.reject("Could not schedule background sync: " + e.getMessage(), e);
+        }
+    }
+
+    @PluginMethod
+    public void cancelBackgroundSync(PluginCall call) {
+        try {
+            HeadlessSyncWorker.cancel(getContext());
+            call.resolve();
+        } catch (Exception e) {
+            call.reject("Could not cancel background sync: " + e.getMessage(), e);
         }
     }
 }

--- a/android/app/src/main/java/calino/malinov/ski/CalendarMirrorWriter.java
+++ b/android/app/src/main/java/calino/malinov/ski/CalendarMirrorWriter.java
@@ -1,0 +1,436 @@
+package calino.malinov.ski;
+
+import android.content.ContentProviderOperation;
+import android.content.ContentProviderResult;
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.graphics.Color;
+import android.net.Uri;
+import android.provider.CalendarContract;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Reconciles Calino's events into Android's calendar provider, one-way and
+ * read-only, so that the OS owns reminder alarms and so the events are visible
+ * to calendar widgets, Wear OS, Android Auto and anything else reading
+ * {@link CalendarContract}.
+ *
+ * <p>The mirror is deliberately <em>not</em> a sync adapter: there is no account
+ * authenticator and nothing ever flows back. We write with
+ * {@code CALLER_IS_SYNCADAPTER=true} purely because the provider only allows
+ * that caller to create calendars and to set the columns we need
+ * (ACCOUNT_TYPE, OWNER_ACCOUNT, CALENDAR_ACCESS_LEVEL). The calendars use
+ * {@link CalendarContract#ACCOUNT_TYPE_LOCAL}, the documented account type for
+ * device-local calendars that no sync adapter owns.
+ *
+ * <p>Ownership is tracked entirely through {@code _SYNC_ID}: a mirrored calendar
+ * carries Calino's calendar id, a mirrored event carries Calino's event id. We
+ * only ever read, update or delete rows inside calendars we created under our
+ * own account name, so a bug here cannot touch the user's Google or Exchange
+ * data.
+ *
+ * <p>{@code SYNC_DATA1} holds a content hash computed on the JS side (see
+ * {@code src/lib/calendarMirror.ts}) so reconcile can skip unchanged events
+ * instead of rewriting the whole mirror on every sync — rewriting churns the
+ * provider's alarm scheduling for events that did not change.
+ *
+ * <p>Kept free of Capacitor types so both {@link CalendarMirrorPlugin} (bridge)
+ * and {@link HeadlessSyncWorker} (no bridge) can drive the same reconcile.
+ */
+final class CalendarMirrorWriter {
+
+    /** Account name for every calendar we create. Also our ownership marker. */
+    private static final String ACCOUNT_NAME = "Calino";
+
+    /**
+     * The provider rejects oversized transactions, and a first sync can produce
+     * thousands of operations, so batches are chunked. Each event contributes
+     * one insert plus one op per reminder, so this stays well under the limit.
+     */
+    private static final int BATCH_SIZE = 400;
+
+    private static final String[] CALENDAR_PROJECTION = {
+        CalendarContract.Calendars._ID,
+        CalendarContract.Calendars._SYNC_ID,
+        CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+        CalendarContract.Calendars.CALENDAR_COLOR,
+    };
+
+    private static final String[] EVENT_PROJECTION = {
+        CalendarContract.Events._ID,
+        CalendarContract.Events._SYNC_ID,
+        CalendarContract.Events.SYNC_DATA1,
+        CalendarContract.Events.CALENDAR_ID,
+    };
+
+    private final Context context;
+
+    CalendarMirrorWriter(Context context) {
+        this.context = context;
+    }
+
+    /** Outcome of one reconcile, for the caller to report back to JS. */
+    static final class Result {
+        final int calendars;
+        final int written;
+        final int removed;
+
+        Result(int calendars, int written, int removed) {
+            this.calendars = calendars;
+            this.written = written;
+            this.removed = removed;
+        }
+
+        JSONObject toJson() throws Exception {
+            JSONObject json = new JSONObject();
+            json.put("calendars", calendars);
+            json.put("written", written);
+            json.put("removed", removed);
+            return json;
+        }
+    }
+
+    /**
+     * Reconciles the mirror against the given calendars and events.
+     *
+     * @param partial when false, {@code calendars} is the complete desired
+     *     state and any mirrored calendar missing from it is deleted. When
+     *     true, the pass is only authoritative for the calendars it lists and
+     *     leaves the rest of the mirror untouched — this is what lets the
+     *     background worker refresh CalDAV calendars without deleting the
+     *     webcal-derived ones it never fetched.
+     */
+    Result sync(JSONArray calendars, JSONArray events, boolean partial) throws Exception {
+        Map<String, Long> calendarIds = reconcileCalendars(calendars, partial);
+        int[] counts = reconcileEvents(events, calendarIds);
+        return new Result(calendarIds.size(), counts[0], counts[1]);
+    }
+
+    /** Removes every calendar (and thus every event) the mirror created. */
+    int clear() {
+        return context
+            .getContentResolver()
+            .delete(syncAdapterUri(CalendarContract.Calendars.CONTENT_URI), ownCalendarSelection(), null);
+    }
+
+    // ---------------------------------------------------------------- calendars
+
+    /**
+     * Creates, updates and (unless {@code partial}) deletes mirrored calendars
+     * so they match the input.
+     *
+     * @return Calino calendar id → provider calendar row id, for the event pass.
+     */
+    private Map<String, Long> reconcileCalendars(JSONArray input, boolean partial) throws Exception {
+        Map<String, JSONObject> desired = new HashMap<>();
+        for (int i = 0; i < input.length(); i++) {
+            JSONObject calendar = input.getJSONObject(i);
+            desired.put(calendar.getString("id"), calendar);
+        }
+
+        Map<String, Long> resolved = new HashMap<>();
+        ContentResolver resolver = context.getContentResolver();
+
+        try (Cursor cursor = resolver.query(
+            syncAdapterUri(CalendarContract.Calendars.CONTENT_URI),
+            CALENDAR_PROJECTION,
+            ownCalendarSelection(),
+            null,
+            null
+        )) {
+            while (cursor != null && cursor.moveToNext()) {
+                long rowId = cursor.getLong(0);
+                String syncId = cursor.getString(1);
+                JSONObject wanted = syncId == null ? null : desired.get(syncId);
+
+                if (wanted == null) {
+                    if (partial) continue;
+                    resolver.delete(
+                        ContentUris.withAppendedId(
+                            syncAdapterUri(CalendarContract.Calendars.CONTENT_URI),
+                            rowId
+                        ),
+                        null,
+                        null
+                    );
+                    continue;
+                }
+
+                // Name and colour are the only mutable fields; rewrite them
+                // only when they actually drifted.
+                String name = wanted.getString("name");
+                int color = parseColor(wanted.optString("color", null));
+                if (!name.equals(cursor.getString(2)) || color != cursor.getInt(3)) {
+                    ContentValues values = new ContentValues();
+                    values.put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, name);
+                    values.put(CalendarContract.Calendars.NAME, name);
+                    values.put(CalendarContract.Calendars.CALENDAR_COLOR, color);
+                    resolver.update(
+                        ContentUris.withAppendedId(
+                            syncAdapterUri(CalendarContract.Calendars.CONTENT_URI),
+                            rowId
+                        ),
+                        values,
+                        null,
+                        null
+                    );
+                }
+
+                resolved.put(syncId, rowId);
+            }
+        }
+
+        for (Map.Entry<String, JSONObject> entry : desired.entrySet()) {
+            if (resolved.containsKey(entry.getKey())) continue;
+            resolved.put(entry.getKey(), insertCalendar(entry.getKey(), entry.getValue()));
+        }
+
+        return resolved;
+    }
+
+    private long insertCalendar(String calinoId, JSONObject calendar) throws Exception {
+        String name = calendar.getString("name");
+
+        ContentValues values = new ContentValues();
+        values.put(CalendarContract.Calendars._SYNC_ID, calinoId);
+        values.put(CalendarContract.Calendars.ACCOUNT_NAME, ACCOUNT_NAME);
+        values.put(CalendarContract.Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL);
+        values.put(CalendarContract.Calendars.OWNER_ACCOUNT, ACCOUNT_NAME);
+        values.put(CalendarContract.Calendars.NAME, name);
+        values.put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, name);
+        values.put(CalendarContract.Calendars.CALENDAR_COLOR, parseColor(calendar.optString("color", null)));
+        // Read-only: Calino stays the single writer, and calendar apps will not
+        // offer to edit events they cannot push back to the CalDAV server.
+        values.put(
+            CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
+            CalendarContract.Calendars.CAL_ACCESS_READ
+        );
+        values.put(CalendarContract.Calendars.VISIBLE, 1);
+        values.put(CalendarContract.Calendars.SYNC_EVENTS, 1);
+        values.put(CalendarContract.Calendars.CALENDAR_TIME_ZONE, java.util.TimeZone.getDefault().getID());
+        // Without an explicit allow-list some calendar apps refuse to surface
+        // our reminder rows at all.
+        values.put(
+            CalendarContract.Calendars.ALLOWED_REMINDERS,
+            String.valueOf(CalendarContract.Reminders.METHOD_ALERT)
+        );
+        values.put(CalendarContract.Calendars.ALLOWED_AVAILABILITY, "0,1");
+        values.put(CalendarContract.Calendars.ALLOWED_ATTENDEE_TYPES, "0,1,2");
+
+        Uri inserted = context
+            .getContentResolver()
+            .insert(syncAdapterUri(CalendarContract.Calendars.CONTENT_URI), values);
+        if (inserted == null) throw new IllegalStateException("Could not create calendar '" + name + "'");
+        return ContentUris.parseId(inserted);
+    }
+
+    // ---------------------------------------------------------------- events
+
+    /** @return {written, removed} */
+    private int[] reconcileEvents(JSONArray input, Map<String, Long> calendarIds) throws Exception {
+        Map<String, JSONObject> desired = new HashMap<>();
+        for (int i = 0; i < input.length(); i++) {
+            JSONObject event = input.getJSONObject(i);
+            // An event in a calendar we did not mirror has nowhere to go.
+            if (calendarIds.containsKey(event.getString("calendarId"))) {
+                desired.put(event.getString("id"), event);
+            }
+        }
+
+        if (calendarIds.isEmpty()) return new int[] { 0, 0 };
+
+        List<ContentProviderOperation> ops = new ArrayList<>();
+        Set<String> upToDate = new HashSet<>();
+        int removed = 0;
+
+        Uri eventsUri = syncAdapterUri(CalendarContract.Events.CONTENT_URI);
+        try (Cursor cursor = context.getContentResolver().query(
+            eventsUri,
+            EVENT_PROJECTION,
+            CalendarContract.Events.CALENDAR_ID + " IN (" + joinIds(calendarIds.values()) + ")",
+            null,
+            null
+        )) {
+            while (cursor != null && cursor.moveToNext()) {
+                long rowId = cursor.getLong(0);
+                String syncId = cursor.getString(1);
+                String hash = cursor.getString(2);
+                long calendarRowId = cursor.getLong(3);
+
+                JSONObject wanted = syncId == null ? null : desired.get(syncId);
+                Long wantedCalendar = wanted == null
+                    ? null
+                    : calendarIds.get(wanted.getString("calendarId"));
+
+                boolean unchanged = wanted != null
+                    && wantedCalendar != null
+                    && wantedCalendar == calendarRowId
+                    && wanted.getString("hash").equals(hash);
+
+                if (unchanged) {
+                    upToDate.add(syncId);
+                    continue;
+                }
+
+                // Changed events are deleted and re-inserted rather than
+                // updated: the reminder rows hang off the event id and would
+                // otherwise need their own diff for no practical gain.
+                ops.add(
+                    ContentProviderOperation
+                        .newDelete(ContentUris.withAppendedId(eventsUri, rowId))
+                        .build()
+                );
+                if (wanted == null) removed++;
+            }
+        }
+
+        int written = 0;
+        for (Map.Entry<String, JSONObject> entry : desired.entrySet()) {
+            if (upToDate.contains(entry.getKey())) continue;
+            appendEventInsert(ops, entry.getKey(), entry.getValue(), calendarIds);
+            written++;
+            if (ops.size() >= BATCH_SIZE) flush(ops);
+        }
+        flush(ops);
+
+        return new int[] { written, removed };
+    }
+
+    private void appendEventInsert(
+        List<ContentProviderOperation> ops,
+        String calinoId,
+        JSONObject event,
+        Map<String, Long> calendarIds
+    ) throws Exception {
+        int eventOpIndex = ops.size();
+
+        ContentProviderOperation.Builder builder = ContentProviderOperation
+            .newInsert(syncAdapterUri(CalendarContract.Events.CONTENT_URI))
+            .withValue(CalendarContract.Events._SYNC_ID, calinoId)
+            .withValue(CalendarContract.Events.SYNC_DATA1, event.getString("hash"))
+            .withValue(CalendarContract.Events.DIRTY, 0)
+            .withValue(
+                CalendarContract.Events.CALENDAR_ID,
+                calendarIds.get(event.getString("calendarId"))
+            )
+            .withValue(CalendarContract.Events.TITLE, event.optString("title", ""))
+            .withValue(CalendarContract.Events.DTSTART, event.getLong("start"))
+            .withValue(CalendarContract.Events.ALL_DAY, event.optBoolean("allDay", false) ? 1 : 0)
+            .withValue(CalendarContract.Events.EVENT_TIMEZONE, event.getString("timezone"))
+            .withValue(
+                CalendarContract.Events.ACCESS_LEVEL,
+                CalendarContract.Events.ACCESS_DEFAULT
+            );
+
+        String description = event.optString("description", null);
+        if (description != null && !description.isEmpty()) {
+            builder.withValue(CalendarContract.Events.DESCRIPTION, description);
+        }
+        String location = event.optString("location", null);
+        if (location != null && !location.isEmpty()) {
+            builder.withValue(CalendarContract.Events.EVENT_LOCATION, location);
+        }
+
+        builder.withValue(
+            CalendarContract.Events.AVAILABILITY,
+            "transparent".equals(event.optString("transparency", null))
+                ? CalendarContract.Events.AVAILABILITY_FREE
+                : CalendarContract.Events.AVAILABILITY_BUSY
+        );
+
+        String rrule = event.optString("rrule", null);
+        if (rrule != null && !rrule.isEmpty()) {
+            // The provider requires recurring events to carry DURATION and to
+            // leave DTEND null; setting both is rejected.
+            builder.withValue(CalendarContract.Events.RRULE, rrule);
+            builder.withValue(CalendarContract.Events.DURATION, event.getString("duration"));
+            String exdate = event.optString("exdate", null);
+            if (exdate != null && !exdate.isEmpty()) {
+                builder.withValue(CalendarContract.Events.EXDATE, exdate);
+            }
+        } else {
+            builder.withValue(CalendarContract.Events.DTEND, event.getLong("end"));
+        }
+
+        JSONArray reminders = event.optJSONArray("reminders");
+        int reminderCount = reminders == null ? 0 : reminders.length();
+        builder.withValue(CalendarContract.Events.HAS_ALARM, reminderCount > 0 ? 1 : 0);
+        ops.add(builder.build());
+
+        for (int i = 0; i < reminderCount; i++) {
+            ops.add(
+                ContentProviderOperation
+                    .newInsert(syncAdapterUri(CalendarContract.Reminders.CONTENT_URI))
+                    // Back-reference: the event row id does not exist until the
+                    // batch is applied.
+                    .withValueBackReference(CalendarContract.Reminders.EVENT_ID, eventOpIndex)
+                    .withValue(CalendarContract.Reminders.MINUTES, reminders.getInt(i))
+                    .withValue(CalendarContract.Reminders.METHOD, CalendarContract.Reminders.METHOD_ALERT)
+                    .build()
+            );
+        }
+    }
+
+    private void flush(List<ContentProviderOperation> ops) throws Exception {
+        if (ops.isEmpty()) return;
+        ContentProviderResult[] results = context
+            .getContentResolver()
+            .applyBatch(CalendarContract.AUTHORITY, new ArrayList<>(ops));
+        if (results.length != ops.size()) {
+            throw new IllegalStateException(
+                "Calendar provider applied " + results.length + " of " + ops.size() + " operations"
+            );
+        }
+        ops.clear();
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /**
+     * Tags a URI as a sync-adapter call. Required to create calendars, to set
+     * the sync columns we key ownership off, and so deletes actually remove
+     * rows instead of tombstoning them as {@code DELETED=1}.
+     */
+    private static Uri syncAdapterUri(Uri uri) {
+        return uri
+            .buildUpon()
+            .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
+            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, ACCOUNT_NAME)
+            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL)
+            .build();
+    }
+
+    /** Restricts every query and delete to calendars this plugin created. */
+    private static String ownCalendarSelection() {
+        return CalendarContract.Calendars.ACCOUNT_NAME + " = '" + ACCOUNT_NAME + "' AND "
+            + CalendarContract.Calendars.ACCOUNT_TYPE + " = '" + CalendarContract.ACCOUNT_TYPE_LOCAL + "'";
+    }
+
+    private static String joinIds(Iterable<Long> ids) {
+        StringBuilder joined = new StringBuilder();
+        for (Long id : ids) {
+            if (joined.length() > 0) joined.append(',');
+            joined.append(id);
+        }
+        return joined.toString();
+    }
+
+    private static int parseColor(String hex) {
+        if (hex == null || hex.isEmpty()) return Color.GRAY;
+        try {
+            return Color.parseColor(hex);
+        } catch (IllegalArgumentException e) {
+            return Color.GRAY;
+        }
+    }
+}

--- a/android/app/src/main/java/calino/malinov/ski/DavHttp.java
+++ b/android/app/src/main/java/calino/malinov/ski/DavHttp.java
@@ -1,0 +1,116 @@
+package calino.malinov.ski;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * The actual WebDAV-capable HTTP client, kept free of Capacitor types.
+ *
+ * <p>{@link DavHttpPlugin} exposes this over the Capacitor bridge for the
+ * foreground app, and {@link HeadlessSyncWorker} calls it directly from its
+ * JavaScript interface — background sync has no bridge to go through (see the
+ * class comment there). Both paths must behave identically, which is why the
+ * logic lives here rather than in either caller.
+ */
+final class DavHttp {
+
+    private static final int TIMEOUT_SECONDS = 30;
+
+    // Redirects are followed natively: .well-known discovery depends on
+    // landing on the redirect target, and unlike the webview we can read the
+    // final URL back off the response.
+    private static final OkHttpClient CLIENT = new OkHttpClient.Builder()
+        .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .followRedirects(true)
+        .followSslRedirects(true)
+        .build();
+
+    private DavHttp() {}
+
+    /**
+     * Performs one request.
+     *
+     * @param options {@code url}, {@code method}, {@code headers}, {@code body}
+     * @return {@code status}, {@code statusText}, {@code url} (post-redirect),
+     *     {@code headers}, {@code body}
+     * @throws IllegalArgumentException for a malformed URL or unusable method,
+     *     which callers surface as a rejected call rather than a network error
+     * @throws IOException for a network-level failure, matching what
+     *     {@code fetch()} reports for the same thing
+     */
+    static JSONObject request(JSONObject options) throws JSONException, IOException {
+        String url = options.optString("url", "");
+        if (url.isEmpty()) throw new IllegalArgumentException("url is required");
+
+        String method = options.optString("method", "GET");
+        Request.Builder builder = new Request.Builder().url(url);
+
+        JSONObject headers = options.optJSONObject("headers");
+        String contentType = null;
+        if (headers != null) {
+            for (Iterator<String> keys = headers.keys(); keys.hasNext();) {
+                String key = keys.next();
+                String value = headers.optString(key, null);
+                if (value == null) continue;
+                builder.header(key, value);
+                if ("content-type".equalsIgnoreCase(key)) {
+                    contentType = value;
+                }
+            }
+        }
+
+        String body = options.isNull("body") ? null : options.optString("body", null);
+        RequestBody requestBody = null;
+        if (body != null) {
+            MediaType mediaType = contentType != null ? MediaType.parse(contentType) : null;
+            requestBody = RequestBody.create(body.getBytes(StandardCharsets.UTF_8), mediaType);
+        } else if (requiresBody(method)) {
+            // OkHttp rejects a null body on POST/PUT/etc; an empty one is the
+            // faithful equivalent of fetch() with no body.
+            requestBody = RequestBody.create(new byte[0], null);
+        }
+
+        builder.method(method.toUpperCase(), requestBody);
+
+        try (Response response = CLIENT.newCall(builder.build()).execute()) {
+            JSONObject responseHeaders = new JSONObject();
+            Headers rawHeaders = response.headers();
+            for (int i = 0; i < rawHeaders.size(); i++) {
+                // Lowercase to match the webview's Headers semantics. Repeated
+                // headers collapse to the last value; DAV responses don't rely
+                // on multi-value headers.
+                responseHeaders.put(rawHeaders.name(i).toLowerCase(), rawHeaders.value(i));
+            }
+
+            ResponseBody responseBody = response.body();
+            String text = responseBody != null ? responseBody.string() : "";
+
+            JSONObject result = new JSONObject();
+            result.put("status", response.code());
+            result.put("statusText", response.message());
+            // The post-redirect URL — discovery compares this against the
+            // requested one to detect a .well-known bounce.
+            result.put("url", response.request().url().toString());
+            result.put("headers", responseHeaders);
+            result.put("body", text);
+            return result;
+        }
+    }
+
+    private static boolean requiresBody(String method) {
+        String m = method.toUpperCase();
+        return m.equals("POST") || m.equals("PUT") || m.equals("PATCH") || m.equals("PROPPATCH");
+    }
+}

--- a/android/app/src/main/java/calino/malinov/ski/DavHttpPlugin.java
+++ b/android/app/src/main/java/calino/malinov/ski/DavHttpPlugin.java
@@ -6,16 +6,7 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
-import java.util.concurrent.TimeUnit;
-import okhttp3.Headers;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
+import org.json.JSONObject;
 
 /**
  * Native HTTP for CalDAV/CardDAV, so DAV sync works against servers that send
@@ -29,103 +20,28 @@ import okhttp3.ResponseBody;
  * MOVE all throw ProtocolException. OkHttp has no such whitelist, so this
  * plugin exists purely to be the third path.
  *
- * The JS side is src/lib/webFetch.ts, which adapts the result back into a
- * Response. Bodies are DAV XML and iCalendar text, so they cross the bridge as
- * strings — no streaming or binary support here, deliberately.
+ * The request itself lives in {@link DavHttp}, shared with the background sync
+ * worker; this class is only the bridge exposure. The JS side is
+ * src/lib/webFetch.ts, which adapts the result back into a Response. Bodies are
+ * DAV XML and iCalendar text, so they cross the bridge as strings — no
+ * streaming or binary support here, deliberately.
  */
 @CapacitorPlugin(name = "DavHttp")
 public class DavHttpPlugin extends Plugin {
 
-    private static final int TIMEOUT_SECONDS = 30;
-
-    // Redirects are followed natively: .well-known discovery depends on
-    // landing on the redirect target, and unlike the webview we can read the
-    // final URL back off the response.
-    private final OkHttpClient client = new OkHttpClient.Builder()
-        .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        .followRedirects(true)
-        .followSslRedirects(true)
-        .build();
-
     @PluginMethod
     public void request(PluginCall call) {
-        String url = call.getString("url");
-        if (url == null || url.isEmpty()) {
-            call.reject("url is required");
-            return;
-        }
-        String method = call.getString("method", "GET");
-
-        Request.Builder builder;
         try {
-            builder = new Request.Builder().url(url);
+            JSONObject result = DavHttp.request(call.getData());
+            call.resolve(JSObject.fromJSONObject(result));
         } catch (IllegalArgumentException e) {
-            call.reject("Invalid URL: " + url, e);
-            return;
-        }
-
-        JSObject headers = call.getObject("headers", new JSObject());
-        String contentType = null;
-        for (Iterator<String> keys = headers.keys(); keys.hasNext();) {
-            String key = keys.next();
-            String value = headers.getString(key);
-            if (value == null) continue;
-            builder.header(key, value);
-            if ("content-type".equalsIgnoreCase(key)) {
-                contentType = value;
-            }
-        }
-
-        String body = call.getString("body");
-        RequestBody requestBody = null;
-        if (body != null) {
-            MediaType mediaType = contentType != null ? MediaType.parse(contentType) : null;
-            requestBody = RequestBody.create(body.getBytes(StandardCharsets.UTF_8), mediaType);
-        } else if (requiresBody(method)) {
-            // OkHttp rejects a null body on POST/PUT/etc; an empty one is the
-            // faithful equivalent of fetch() with no body.
-            requestBody = RequestBody.create(new byte[0], null);
-        }
-
-        try {
-            builder.method(method.toUpperCase(), requestBody);
-        } catch (IllegalArgumentException e) {
-            call.reject("Unsupported method: " + method, e);
-            return;
-        }
-
-        try (Response response = client.newCall(builder.build()).execute()) {
-            JSObject responseHeaders = new JSObject();
-            Headers rawHeaders = response.headers();
-            for (int i = 0; i < rawHeaders.size(); i++) {
-                // Lowercase to match the webview's Headers semantics. Repeated
-                // headers collapse to the last value; DAV responses don't rely
-                // on multi-value headers.
-                responseHeaders.put(rawHeaders.name(i).toLowerCase(), rawHeaders.value(i));
-            }
-
-            ResponseBody responseBody = response.body();
-            String text = responseBody != null ? responseBody.string() : "";
-
-            JSObject result = new JSObject();
-            result.put("status", response.code());
-            result.put("statusText", response.message());
-            // The post-redirect URL — discovery compares this against the
-            // requested one to detect a .well-known bounce.
-            result.put("url", response.request().url().toString());
-            result.put("headers", responseHeaders);
-            result.put("body", text);
-            call.resolve(result);
+            call.reject(e.getMessage(), e);
         } catch (IOException e) {
             // Network-level failure. webFetch.ts turns this back into a
             // rejected promise, matching how fetch() reports the same thing.
             call.reject(e.getMessage() != null ? e.getMessage() : "Network request failed", e);
+        } catch (Exception e) {
+            call.reject("DAV request failed: " + e.getMessage(), e);
         }
-    }
-
-    private static boolean requiresBody(String method) {
-        String m = method.toUpperCase();
-        return m.equals("POST") || m.equals("PUT") || m.equals("PATCH") || m.equals("PROPPATCH");
     }
 }

--- a/android/app/src/main/java/calino/malinov/ski/HeadlessSyncWorker.java
+++ b/android/app/src/main/java/calino/malinov/ski/HeadlessSyncWorker.java
@@ -1,0 +1,319 @@
+package calino.malinov.ski;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.work.Constraints;
+import androidx.work.ExistingPeriodicWorkPolicy;
+import androidx.work.NetworkType;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLConnection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.json.JSONObject;
+
+/**
+ * Periodic background CalDAV refresh, so the mirror holds events Calino has
+ * never seen in the foreground.
+ *
+ * <p>Without this the mirror only ever contains what the app knew last time it
+ * was open: the OS reliably alarms whatever is in {@link android.provider.CalendarContract},
+ * but an event someone added on another device never gets there. This worker
+ * closes that gap.
+ *
+ * <h3>Why a WebView</h3>
+ *
+ * Calino's CalDAV engine is TypeScript in {@code src/}, and there is deliberately
+ * one codebase for web and Android — reimplementing CalDAV and iCalendar parsing
+ * in Java would mean two engines to keep in step. So the worker runs the real
+ * engine instead, in a bare WebView.
+ *
+ * <p>It cannot use Capacitor to do that: {@code Bridge} requires an
+ * {@code AppCompatActivity} (see its constructor), a worker has none, and
+ * Android 10+ forbids starting an activity from the background. So the page is
+ * served and driven by hand here, and the two native capabilities the sync
+ * needs — DAV HTTP and the provider write — are exposed as a plain
+ * {@code @JavascriptInterface} instead of Capacitor plugins. {@code src/headless.ts}
+ * is the other half; {@code src/lib/webFetch.ts} routes through this bridge when
+ * it is present.
+ *
+ * <p>The page is served at {@code https://localhost}, byte for byte the origin
+ * Capacitor uses, which is the entire reason this works: same origin means the
+ * same {@code localStorage}, so the worker reads the accounts, credentials and
+ * calendar visibility the app already stored, with no separate copy to keep in
+ * sync.
+ *
+ * <h3>What it must not do</h3>
+ *
+ * The headless page is <em>read-only</em> with respect to app state. It never
+ * writes {@code localStorage}. If it did, it would race the foreground app,
+ * whose zustand store holds its own in-memory copy and rehydrates only at
+ * startup — a background write would either be clobbered on the next foreground
+ * save or clobber a change the user just made. Instead the worker fetches and
+ * writes only the provider, and the app re-mirrors from its own state when it
+ * next opens. The two converge because the mirror is derived state, reconciled
+ * by content hash.
+ *
+ * <p>Its reconcile is also {@code partial} (see {@link CalendarMirrorWriter}):
+ * it refreshes only the CalDAV calendars it actually fetched, and leaves rows
+ * from webcal subscriptions — which it does not sync — alone rather than
+ * deleting them as absent.
+ */
+public class HeadlessSyncWorker extends Worker {
+
+    private static final String TAG = "CalinoHeadlessSync";
+    private static final String WORK_NAME = "calino-background-sync";
+
+    /**
+     * WorkManager's floor is 15 minutes and it batches work across the system
+     * anyway, so this is a hint rather than a schedule. Hourly keeps the mirror
+     * fresh enough for reminders without waking the radio all day.
+     */
+    static final long DEFAULT_INTERVAL_MINUTES = 60;
+
+    /**
+     * Budget for the whole pass. WorkManager allows ten minutes before it kills
+     * the worker; stopping short of that lets us tear the WebView down cleanly
+     * and log a timeout instead of dying mid-write.
+     */
+    private static final long TIMEOUT_MINUTES = 5;
+
+    /** Origin Capacitor serves the app from — must match for shared storage. */
+    private static final String ORIGIN = "https://localhost";
+    private static final String ENTRY_URL = ORIGIN + "/headless.html";
+    /** Where `npx cap sync` puts the built web bundle inside assets. */
+    private static final String ASSET_ROOT = "public";
+
+    public HeadlessSyncWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    // ---------------------------------------------------------------- scheduling
+
+    static void schedule(Context context, long intervalMinutes) {
+        Constraints constraints = new Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build();
+
+        PeriodicWorkRequest request = new PeriodicWorkRequest.Builder(
+            HeadlessSyncWorker.class,
+            Math.max(intervalMinutes, PeriodicWorkRequest.MIN_PERIODIC_INTERVAL_MILLIS / 60000),
+            TimeUnit.MINUTES
+        )
+            .setConstraints(constraints)
+            .build();
+
+        // UPDATE rather than KEEP so a changed interval takes effect without
+        // losing the existing schedule's elapsed time.
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        );
+    }
+
+    static void cancel(Context context) {
+        WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME);
+    }
+
+    // ---------------------------------------------------------------- the pass
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        Log.i(TAG, "Background sync starting");
+        if (!hasCalendarPermission(getApplicationContext())) {
+            // The user revoked it since the setting was turned on. Nothing to
+            // write, and nothing we can do about it from the background.
+            Log.i(TAG, "Calendar permission not granted; skipping background sync");
+            return Result.success();
+        }
+
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<String> failure = new AtomicReference<>(null);
+        AtomicReference<WebView> webViewRef = new AtomicReference<>(null);
+        Handler main = new Handler(Looper.getMainLooper());
+
+        // A WebView must be created and destroyed on the main thread, but
+        // doWork() runs off it — hence the hop out and the latch back.
+        main.post(() -> {
+            try {
+                webViewRef.set(createWebView(done, failure));
+                webViewRef.get().loadUrl(ENTRY_URL);
+            } catch (Throwable t) {
+                failure.set("Could not start headless WebView: " + t.getMessage());
+                done.countDown();
+            }
+        });
+
+        boolean finished;
+        try {
+            finished = done.await(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            finished = false;
+        }
+
+        main.post(() -> {
+            WebView webView = webViewRef.getAndSet(null);
+            if (webView != null) {
+                webView.loadUrl("about:blank");
+                webView.destroy();
+            }
+        });
+
+        if (!finished) {
+            Log.w(TAG, "Background sync timed out after " + TIMEOUT_MINUTES + " minutes");
+            return Result.retry();
+        }
+        String error = failure.get();
+        if (error != null) {
+            Log.w(TAG, "Background sync failed: " + error);
+            // Almost always a transient network or server problem; the next
+            // period would retry anyway, but backing off gets there sooner.
+            return Result.retry();
+        }
+        return Result.success();
+    }
+
+    static boolean hasCalendarPermission(Context context) {
+        return ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
+            == PackageManager.PERMISSION_GRANTED;
+    }
+
+    @SuppressWarnings("SetJavaScriptEnabled")
+    private WebView createWebView(CountDownLatch done, AtomicReference<String> failure) {
+        WebView webView = new WebView(getApplicationContext());
+
+        WebSettings settings = webView.getSettings();
+        settings.setJavaScriptEnabled(true);
+        // localStorage is where the accounts, credentials and calendar
+        // visibility live — the whole point of matching Capacitor's origin.
+        settings.setDomStorageEnabled(true);
+        settings.setDatabaseEnabled(true);
+
+        webView.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+                return serveAsset(request);
+            }
+        });
+
+        webView.addJavascriptInterface(new Bridge(done, failure), "CalinoHeadless");
+        return webView;
+    }
+
+    /**
+     * Serves the bundled web build for {@code https://localhost/...}. This is
+     * what gives the page Capacitor's origin without Capacitor.
+     *
+     * <p>Anything off that origin is refused rather than passed through: all
+     * the traffic this page legitimately makes goes over the JS bridge, so a
+     * request reaching the network here would mean the page loaded something it
+     * should not have.
+     */
+    private WebResourceResponse serveAsset(WebResourceRequest request) {
+        if (!ORIGIN.equals(
+            request.getUrl().getScheme() + "://" + request.getUrl().getAuthority()
+        )) {
+            return new WebResourceResponse("text/plain", "UTF-8", 403, "Forbidden", null, null);
+        }
+
+        String path = request.getUrl().getPath();
+        if (path == null || path.equals("/")) path = "/headless.html";
+
+        try {
+            InputStream stream = getApplicationContext().getAssets().open(ASSET_ROOT + path);
+            String mimeType = URLConnection.guessContentTypeFromName(path);
+            if (mimeType == null) mimeType = "application/octet-stream";
+            // guessContentTypeFromName has no idea about ES modules, and a
+            // WebView refuses to execute a script served as anything else.
+            if (path.endsWith(".js") || path.endsWith(".mjs")) mimeType = "text/javascript";
+            if (path.endsWith(".css")) mimeType = "text/css";
+            return new WebResourceResponse(mimeType, "UTF-8", stream);
+        } catch (IOException e) {
+            return new WebResourceResponse("text/plain", "UTF-8", 404, "Not Found", null, null);
+        }
+    }
+
+    // ---------------------------------------------------------------- JS bridge
+
+    /**
+     * The two native capabilities the headless sync needs, plus a way to say it
+     * is done. Methods are invoked on the WebView's JavaScript thread, not the
+     * main thread, so blocking here is safe and keeps the JS side simple —
+     * {@code davRequest} is a synchronous call returning the response as JSON.
+     */
+    private final class Bridge {
+        private final CountDownLatch done;
+        private final AtomicReference<String> failure;
+
+        Bridge(CountDownLatch done, AtomicReference<String> failure) {
+            this.done = done;
+            this.failure = failure;
+        }
+
+        @JavascriptInterface
+        public String davRequest(String optionsJson) {
+            JSONObject result = new JSONObject();
+            try {
+                result.put("ok", true);
+                result.put("response", DavHttp.request(new JSONObject(optionsJson)));
+            } catch (Exception e) {
+                try {
+                    result.put("ok", false);
+                    result.put("error", e.getMessage() != null ? e.getMessage() : e.toString());
+                } catch (Exception ignored) {
+                    return "{\"ok\":false,\"error\":\"request failed\"}";
+                }
+            }
+            return result.toString();
+        }
+
+        @JavascriptInterface
+        public String mirrorSync(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                CalendarMirrorWriter.Result result = new CalendarMirrorWriter(getApplicationContext())
+                    .sync(
+                        payload.getJSONArray("calendars"),
+                        payload.getJSONArray("events"),
+                        // Authoritative only for the calendars it fetched.
+                        true
+                    );
+                return result.toJson().toString();
+            } catch (Exception e) {
+                Log.w(TAG, "Mirror write failed", e);
+                return "{\"error\":" + JSONObject.quote(String.valueOf(e.getMessage())) + "}";
+            }
+        }
+
+        @JavascriptInterface
+        public void log(String message) {
+            Log.i(TAG, message);
+        }
+
+        @JavascriptInterface
+        public void finish(String error) {
+            if (error != null && !error.isEmpty()) failure.set(error);
+            done.countDown();
+        }
+    }
+}

--- a/android/app/src/main/java/calino/malinov/ski/MainActivity.java
+++ b/android/app/src/main/java/calino/malinov/ski/MainActivity.java
@@ -1,7 +1,9 @@
 package calino.malinov.ski;
 
 import android.os.Bundle;
+import android.webkit.WebView;
 import com.getcapacitor.BridgeActivity;
+import com.getcapacitor.WebViewListener;
 
 public class MainActivity extends BridgeActivity {
     @Override
@@ -13,5 +15,20 @@ public class MainActivity extends BridgeActivity {
         // composited, regardless of what CSS/JS sets — without this, there's a
         // flash of white between the launch splash and the page's first paint.
         getBridge().getWebView().setBackgroundColor(getResources().getColor(R.color.splashBackground, getTheme()));
+
+        // Safety net for OEM WebViews that Capacitor's own safe-area handling
+        // skips — see SafeAreaInsets and issue #95.
+        final Runnable invalidateSafeArea = SafeAreaInsets.install(this, getBridge().getWebView());
+        getBridge()
+            .addWebViewListener(
+                new WebViewListener() {
+                    @Override
+                    public void onPageCommitVisible(WebView view, String url) {
+                        super.onPageCommitVisible(view, url);
+                        invalidateSafeArea.run();
+                        view.requestApplyInsets();
+                    }
+                }
+            );
     }
 }

--- a/android/app/src/main/java/calino/malinov/ski/MainActivity.java
+++ b/android/app/src/main/java/calino/malinov/ski/MainActivity.java
@@ -10,6 +10,7 @@ public class MainActivity extends BridgeActivity {
     public void onCreate(Bundle savedInstanceState) {
         registerPlugin(DynamicShortcutsPlugin.class);
         registerPlugin(DavHttpPlugin.class);
+        registerPlugin(CalendarMirrorPlugin.class);
         super.onCreate(savedInstanceState);
         // The WebView's native surface is opaque white until content is actually
         // composited, regardless of what CSS/JS sets — without this, there's a

--- a/android/app/src/main/java/calino/malinov/ski/SafeAreaInsets.java
+++ b/android/app/src/main/java/calino/malinov/ski/SafeAreaInsets.java
@@ -1,0 +1,104 @@
+package calino.malinov.ski;
+
+import android.app.Activity;
+import android.view.View;
+import android.webkit.WebView;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import java.util.Locale;
+
+/**
+ * Writes the real window insets into the `--safe-area-inset-*` CSS variables.
+ *
+ * Capacitor's built-in SystemBars plugin already does this, but only down a
+ * code path gated on `WebViewCompat.getCurrentWebViewPackage()` returning a
+ * numeric major version >= 140. On OEM-forked Android that ships its own
+ * WebView build (issue #95: Huawei/EMUI) that lookup can return null or a
+ * version string whose first segment doesn't parse, and the variables are then
+ * never set at all — so `--safe-area-top` resolves to its 0px fallback and the
+ * header renders underneath the status bar.
+ *
+ * This listener asks the OS the one question that every Android build answers
+ * correctly ("how much of my window is covered by system UI?") and publishes
+ * the answer, with no version sniffing in between.
+ *
+ * It is deliberately additive: it attaches to the activity's content view,
+ * which is the *parent* of the CoordinatorLayout that SystemBars attaches to,
+ * and returns the insets unmodified so that SystemBars still receives the real
+ * values and keeps doing its own padding and keyboard correction. On devices
+ * where SystemBars already works, both write the same numbers.
+ */
+final class SafeAreaInsets {
+
+    private SafeAreaInsets() {}
+
+    /**
+     * @return a callback that forgets the last written values, so the next
+     *     inset dispatch re-injects them. Call it after a navigation: the
+     *     variables live in an inline style on `<html>`, which the new
+     *     document doesn't inherit.
+     */
+    static Runnable install(Activity activity, WebView webView) {
+        View content = activity.findViewById(android.R.id.content);
+        if (content == null || webView == null) {
+            return () -> {};
+        }
+
+        // Remembered so a burst of inset dispatches doesn't turn into a burst
+        // of evaluateJavascript calls.
+        final int[] last = { -1, -1, -1, -1 };
+
+        ViewCompat.setOnApplyWindowInsetsListener(content, (v, insets) -> {
+            Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+
+            // The keyboard is handled natively (Keyboard.resize = Native
+            // resizes the WebView window itself), so the gesture-bar inset is
+            // already gone from the visible viewport while the IME is up.
+            // Reporting it again would double-pad the bottom.
+            int bottom = insets.isVisible(WindowInsetsCompat.Type.ime()) ? 0 : bars.bottom;
+
+            float density = activity.getResources().getDisplayMetrics().density;
+            int top = (int) (bars.top / density);
+            int right = (int) (bars.right / density);
+            int bottomDp = (int) (bottom / density);
+            int left = (int) (bars.left / density);
+
+            if (top != last[0] || right != last[1] || bottomDp != last[2] || left != last[3]) {
+                last[0] = top;
+                last[1] = right;
+                last[2] = bottomDp;
+                last[3] = left;
+                webView.evaluateJavascript(script(top, right, bottomDp, left), null);
+            }
+
+            // Untouched — SystemBars listens further down the hierarchy and
+            // still needs to see the real insets.
+            return insets;
+        });
+
+        return () -> {
+            last[0] = -1;
+            last[1] = -1;
+            last[2] = -1;
+            last[3] = -1;
+        };
+    }
+
+    private static String script(int top, int right, int bottom, int left) {
+        return String.format(
+            Locale.US,
+            "try {" +
+            "  var s = document.documentElement.style;" +
+            "  s.setProperty('--safe-area-inset-top', '%dpx');" +
+            "  s.setProperty('--safe-area-inset-right', '%dpx');" +
+            "  s.setProperty('--safe-area-inset-bottom', '%dpx');" +
+            "  s.setProperty('--safe-area-inset-left', '%dpx');" +
+            "} catch (e) { console.error('safe-area injection failed', e); }",
+            top,
+            right,
+            bottom,
+            left
+        );
+    }
+}

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -14,4 +14,5 @@ ext {
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
     okhttpVersion = '4.12.0'
+    androidxWorkVersion = '2.10.0'
 }

--- a/headless.html
+++ b/headless.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Calino background sync</title>
+  </head>
+  <body>
+    <!--
+      Never displayed. HeadlessSyncWorker loads this page in an offscreen
+      WebView to run a CalDAV pass while the app is closed — see src/headless.ts.
+    -->
+    <script type="module" src="/src/headless.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calino",
   "private": true,
-  "version": "0.26.0",
+  "version": "0.27.0-beta.1",
   "type": "module",
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import { initContactPhotos } from './lib/contactPhotoSync'
 import { useCalDAV } from './features/caldav/hooks/useCalDAV'
 import { useNativeKeyboard } from './hooks/useNativeKeyboard'
 import { useNotifications } from './hooks/useNotifications'
+import { useCalendarMirror } from './hooks/useCalendarMirror'
 import { openEventDeepLink } from './lib/deepLink'
 import { AIPhotoImportRoot } from './features/aiVision/components/AIPhotoImportRoot'
 import { useAIPhotoImport } from './features/aiVision/useAIPhotoImport'
@@ -322,6 +323,9 @@ function CalendarApp(): JSX.Element {
   // Fire event/task reminders (web: polling + Notification API; native:
   // real OS-scheduled notifications). Was defined but never mounted anywhere
   // in the app — reminders have never actually fired, on web or native.
+  // Must run before useNotifications reads the mirror status, so the two
+  // don't both schedule reminders on the first pass after launch.
+  useCalendarMirror()
   useNotifications()
 
   // Keep the focused field above the Android on-screen keyboard.

--- a/src/__tests__/headless.test.ts
+++ b/src/__tests__/headless.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { CalendarEvent } from '@/types'
+import type { HeadlessBridge } from '@/lib/headlessBridge'
+
+const mockGetAllAccounts = vi.fn()
+const mockGetCalendarsByAccountId = vi.fn()
+const mockGetCredentialById = vi.fn()
+const mockFetchEvents = vi.fn()
+const mockCreateClient = vi.fn()
+const mockParse = vi.fn()
+
+vi.mock('@/features/caldav/sync/accountStorage', () => ({
+  getAllAccounts: () => mockGetAllAccounts(),
+  getCalendarsByAccountId: (id: string) => mockGetCalendarsByAccountId(id),
+}))
+
+vi.mock('@/features/caldav/client/credentials', () => ({
+  getCredentialById: (id: string) => mockGetCredentialById(id),
+}))
+
+vi.mock('@/features/caldav/client/CalDAVClient', () => ({
+  createCalDAVClient: (...args: unknown[]) => mockCreateClient(...args),
+}))
+
+vi.mock('@/features/caldav/adapter/iCalendarAdapter', () => ({
+  parseICALData: (data: string, calendarId: string) => mockParse(data, calendarId),
+}))
+
+// Imported after the mocks are declared; the module only auto-runs when the
+// native bridge is already on globalThis, which it is not at import time.
+const { runHeadlessSync } = await import('../headless')
+
+function bridgeStub(): HeadlessBridge & { synced: string[] } {
+  const synced: string[] = []
+  return {
+    synced,
+    davRequest: () => '{"ok":true}',
+    mirrorSync: (payload: string) => {
+      synced.push(payload)
+      return '{"calendars":1,"written":1,"removed":0}'
+    },
+    log: () => {},
+    finish: () => {},
+  }
+}
+
+function event(id: string, calendarId: string): CalendarEvent {
+  return {
+    id,
+    calendarId,
+    title: id,
+    start: '2026-08-10T09:00:00.000Z',
+    end: '2026-08-10T09:30:00.000Z',
+    isAllDay: false,
+  }
+}
+
+// The shared test setup replaces localStorage with bare vi.fn()s, so back it
+// with a real map here — this suite is specifically about what the headless
+// page reads out of it and what it must not write back.
+const stored = new Map<string, string>()
+
+/** The app's persisted store, which the headless page reads but never writes. */
+function persistCalendars(calendars: { id: string; isVisible: boolean }[]): void {
+  stored.set(
+    'calino-storage',
+    JSON.stringify({
+      state: {
+        calendars: calendars.map((c) => ({ ...c, name: c.id, color: '#ff0000' })),
+      },
+    })
+  )
+}
+
+let bridge: ReturnType<typeof bridgeStub>
+
+describe('runHeadlessSync', () => {
+  beforeEach(() => {
+    stored.clear()
+    vi.mocked(localStorage.getItem).mockImplementation((key: string) => stored.get(key) ?? null)
+    vi.mocked(localStorage.setItem).mockClear()
+    bridge = bridgeStub()
+    ;(globalThis as { CalinoHeadless?: HeadlessBridge }).CalinoHeadless = bridge
+
+    mockGetAllAccounts.mockReset().mockReturnValue([
+      { id: 'acct-1', name: 'Radicale', serverUrl: 'https://dav.test', proxyUrl: null, credentialId: 'cred-1' },
+    ])
+    mockGetCalendarsByAccountId
+      .mockReset()
+      .mockReturnValue([{ id: 'cal-1', url: 'https://dav.test/cal-1/', name: 'Personal' }])
+    mockGetCredentialById.mockReset().mockResolvedValue({ id: 'cred-1', password: 'pw' })
+    mockFetchEvents.mockReset().mockResolvedValue([{ url: 'a.ics', data: 'BEGIN:VCALENDAR' }])
+    mockCreateClient.mockReset().mockResolvedValue({ fetchEvents: mockFetchEvents })
+    mockParse.mockReset().mockImplementation((_data, calendarId) => [event('e1', calendarId)])
+
+    persistCalendars([{ id: 'cal-1', isVisible: true }])
+  })
+
+  afterEach(() => {
+    delete (globalThis as { CalinoHeadless?: HeadlessBridge }).CalinoHeadless
+  })
+
+  it('fetches visible calendars and writes them to the mirror', async () => {
+    const result = await runHeadlessSync()
+
+    expect(result).toEqual({ accounts: 1, calendars: 1, events: 1 })
+    const payload = JSON.parse(bridge.synced[0]) as { events: { id: string }[] }
+    expect(payload.events.map((e) => e.id)).toEqual(['e1'])
+  })
+
+  it('leaves hidden calendars alone', async () => {
+    persistCalendars([{ id: 'cal-1', isVisible: false }])
+
+    const result = await runHeadlessSync()
+
+    expect(mockFetchEvents).not.toHaveBeenCalled()
+    expect(bridge.synced).toEqual([])
+    expect(result.calendars).toBe(0)
+  })
+
+  it('does not write an empty mirror when nothing could be fetched', async () => {
+    // An empty payload is indistinguishable from "the user deleted everything",
+    // and a partial reconcile would then wipe rows the app wrote correctly.
+    mockCreateClient.mockRejectedValue(new Error('offline'))
+
+    const result = await runHeadlessSync()
+
+    expect(bridge.synced).toEqual([])
+    expect(result.events).toBe(0)
+  })
+
+  it('still mirrors the calendars that succeeded when one fails', async () => {
+    mockGetCalendarsByAccountId.mockReturnValue([
+      { id: 'cal-1', url: 'https://dav.test/cal-1/', name: 'Personal' },
+      { id: 'cal-2', url: 'https://dav.test/cal-2/', name: 'Work' },
+    ])
+    persistCalendars([
+      { id: 'cal-1', isVisible: true },
+      { id: 'cal-2', isVisible: true },
+    ])
+    mockFetchEvents.mockImplementation((url: string) => {
+      if (url.endsWith('cal-2/')) return Promise.reject(new Error('500'))
+      return Promise.resolve([{ url: 'a.ics', data: 'BEGIN:VCALENDAR' }])
+    })
+
+    const result = await runHeadlessSync()
+
+    expect(result.calendars).toBe(1)
+    const payload = JSON.parse(bridge.synced[0]) as { calendars: { id: string }[] }
+    expect(payload.calendars.map((c) => c.id)).toEqual(['cal-1'])
+  })
+
+  it('never writes to the app store it reads from', async () => {
+    // A background write would race the foreground app's in-memory zustand
+    // copy, which only rehydrates at startup. The provider is the only thing
+    // this page is allowed to mutate.
+    await runHeadlessSync()
+    expect(localStorage.setItem).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a provider write failure so the worker retries', async () => {
+    bridge.mirrorSync = () => '{"error":"provider exploded"}'
+    await expect(runHeadlessSync()).rejects.toThrow('provider exploded')
+  })
+})

--- a/src/features/commandPalette/__tests__/useCommandPalette.test.ts
+++ b/src/features/commandPalette/__tests__/useCommandPalette.test.ts
@@ -130,6 +130,7 @@ vi.mock('@/store/settingsStore', () => ({
       defaultReminderMinutes: 15,
       defaultEventColor: '#4285F4',
       enableDesktopNotifications: false,
+      enableCalendarMirror: false,
       enableSoundAlerts: false,
       enableHaptics: true,
       conflictResolution: 'local-wins',

--- a/src/features/settings/components/NotificationSettings.tsx
+++ b/src/features/settings/components/NotificationSettings.tsx
@@ -13,6 +13,12 @@ import {
   checkNativeReminderPermission,
   scheduleTestReminder,
 } from '@/lib/nativeReminders'
+import {
+  isCalendarMirrorSupported,
+  checkCalendarMirrorPermission,
+  requestCalendarMirrorPermission,
+} from '@/lib/calendarMirror'
+import { useCalendarMirrorStore } from '@/store/calendarMirrorStore'
 import styles from './Settings.module.css'
 
 // R3.9 — copy reused by both the toggle and the test button when the
@@ -22,9 +28,16 @@ const PERMISSION_DENIED_TOAST =
   'Notifications are blocked. Update site permissions in your browser settings to enable reminders.'
 
 const isNative = Capacitor.isNativePlatform()
+const supportsCalendarMirror = isCalendarMirrorSupported()
+
+const CALENDAR_PERMISSION_DENIED_TOAST =
+  'Calendar access is blocked. Grant it in Android app settings to sync events to your device calendar.'
 
 export function NotificationSettings(): JSX.Element {
   const enableDesktopNotifications = useSettingsStore((s) => s.enableDesktopNotifications)
+  const enableCalendarMirror = useSettingsStore((s) => s.enableCalendarMirror)
+  const mirrorStatus = useCalendarMirrorStore((s) => s.status)
+  const mirrorError = useCalendarMirrorStore((s) => s.lastError)
   const enableSoundAlerts = useSettingsStore((s) => s.enableSoundAlerts)
   const taskDueDateReminders = useSettingsStore((s) => s.taskDueDateReminders)
   const overdueTaskBadge = useSettingsStore((s) => s.overdueTaskBadge)
@@ -61,6 +74,22 @@ export function NotificationSettings(): JSX.Element {
       return
     }
     updateSettings({ enableDesktopNotifications: !enableDesktopNotifications })
+  }
+
+  const handleToggleCalendarMirror = async (): Promise<void> => {
+    if (enableCalendarMirror) {
+      // Turning it off tears the mirrored calendars back down — see
+      // useCalendarMirror. No permission needed to stop.
+      updateSettings({ enableCalendarMirror: false })
+      return
+    }
+    const granted =
+      (await checkCalendarMirrorPermission()) || (await requestCalendarMirrorPermission())
+    if (!granted) {
+      toast.error(CALENDAR_PERMISSION_DENIED_TOAST, { duration: 8000 })
+      return
+    }
+    updateSettings({ enableCalendarMirror: true })
   }
 
   const handleTestNotification = async (): Promise<void> => {
@@ -151,6 +180,47 @@ export function NotificationSettings(): JSX.Element {
           </div>
         </div>
       </div>
+
+      {supportsCalendarMirror && (
+        <div className={styles.group}>
+          <div className={styles.groupLabel}>Device calendar</div>
+          <div
+            className={styles.row}
+            data-component="setting-row"
+            data-setting="calendar-mirror"
+            data-value={String(enableCalendarMirror)}
+          >
+            <div className={styles.rowInfo}>
+              <div className={styles.rowLabel}>Sync to Android Calendar</div>
+              <div className={styles.rowDesc}>
+                {!enableCalendarMirror
+                  ? 'Copy your events into the device calendar so Android delivers reminders even when Calino is closed, and widgets, Wear OS and Android Auto can see them. Read-only — nothing is written back to your CalDAV server.'
+                  : mirrorStatus === 'active'
+                    ? 'Android is delivering your reminders. Events are visible to widgets, Wear OS and Android Auto.'
+                    : mirrorStatus === 'no-calendar-app'
+                      ? 'Events are synced, but no calendar app is installed to raise reminders — Calino is still handling those itself.'
+                      : mirrorStatus === 'denied'
+                        ? 'Calendar access is unavailable. Re-grant it in Android app settings.'
+                        : mirrorStatus === 'failed'
+                          ? `Could not write to the device calendar${mirrorError ? `: ${mirrorError}` : '.'}`
+                          : 'Syncing…'}
+              </div>
+            </div>
+            <div className={styles.rowControl}>
+              <label className={styles.toggle} data-component="toggle" data-setting="calendar-mirror">
+                <input
+                  type="checkbox"
+                  checked={enableCalendarMirror}
+                  aria-label="Sync to Android Calendar"
+                  onChange={handleToggleCalendarMirror}
+                />
+                <span className={styles.pill} />
+                <span className={styles.knob} />
+              </label>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className={styles.group}>
         <div className={styles.groupLabel}>Tasks</div>

--- a/src/features/settings/components/NotificationSettings.tsx
+++ b/src/features/settings/components/NotificationSettings.tsx
@@ -19,6 +19,7 @@ import {
   requestCalendarMirrorPermission,
 } from '@/lib/calendarMirror'
 import { useCalendarMirrorStore } from '@/store/calendarMirrorStore'
+import { Modal } from '@/components/common/Modal'
 import styles from './Settings.module.css'
 
 // R3.9 — copy reused by both the toggle and the test button when the
@@ -45,6 +46,7 @@ export function NotificationSettings(): JSX.Element {
   const [permissionStatus, setPermissionStatus] = useState(
     isNative ? 'default' : getNotificationPermission()
   )
+  const [showMirrorInfo, setShowMirrorInfo] = useState(false)
 
   useEffect(() => {
     if (!isNative) return
@@ -191,7 +193,7 @@ export function NotificationSettings(): JSX.Element {
             data-value={String(enableCalendarMirror)}
           >
             <div className={styles.rowInfo}>
-              <div className={styles.rowLabel}>Sync to Android Calendar</div>
+              <div className={styles.rowLabel}>Sync to Android Calendar (beta)</div>
               <div className={styles.rowDesc}>
                 {!enableCalendarMirror
                   ? 'Copy your events into the device calendar so Android delivers reminders even when Calino is closed, and widgets, Wear OS and Android Auto can see them. Read-only — nothing is written back to your CalDAV server.'
@@ -211,7 +213,7 @@ export function NotificationSettings(): JSX.Element {
                 <input
                   type="checkbox"
                   checked={enableCalendarMirror}
-                  aria-label="Sync to Android Calendar"
+                  aria-label="Sync to Android Calendar (beta)"
                   onChange={handleToggleCalendarMirror}
                 />
                 <span className={styles.pill} />
@@ -219,8 +221,99 @@ export function NotificationSettings(): JSX.Element {
               </label>
             </div>
           </div>
+          <div
+            className={styles.row}
+            data-component="setting-row"
+            data-setting="calendar-mirror-info"
+          >
+            <div className={styles.rowInfo}>
+              <div className={styles.rowLabel}>How this works</div>
+              <div className={styles.rowDesc}>
+                What gets copied, who delivers your reminders, and what to expect in beta
+              </div>
+            </div>
+            <div className={styles.rowControl}>
+              <button
+                className={styles.actionBtn}
+                onClick={() => setShowMirrorInfo(true)}
+                data-component="action-button"
+                data-action="calendar-mirror-info"
+                type="button"
+              >
+                Learn more
+              </button>
+            </div>
+          </div>
         </div>
       )}
+
+      <Modal
+        isOpen={showMirrorInfo}
+        onClose={() => setShowMirrorInfo(false)}
+        title="Sync to Android Calendar"
+      >
+        <div className={styles.infoBody}>
+          <p>
+            Calino copies your events into Android&apos;s own calendar database — the same one your
+            calendar widget, Wear OS watch and Android Auto read from. Those apps can&apos;t see
+            Calino&apos;s storage, so this is what makes your events show up in them.
+          </p>
+
+          <div className={styles.infoSection}>
+            <h3>Why it makes reminders more reliable</h3>
+            <p>
+              On its own, Calino can only schedule a reminder while it&apos;s running. Android
+              schedules reminders for events in its calendar whether or not Calino has been opened,
+              so while this is on, Android delivers them and Calino stands down — you won&apos;t get
+              two notifications for the same event.
+            </p>
+            <p>
+              This needs a calendar app installed to actually raise the notification. If you
+              don&apos;t have one, Calino says so above and keeps handling reminders itself.
+            </p>
+          </div>
+
+          <div className={styles.infoSection}>
+            <h3>It only goes one way</h3>
+            <ul>
+              <li>
+                The mirrored calendars are read-only. Calino stays the only thing that writes to
+                your CalDAV server, and nothing you do in another calendar app comes back.
+              </li>
+              <li>Only calendars you&apos;ve set to visible are copied.</li>
+              <li>
+                Turning this off deletes the mirrored calendars again, leaving your other calendars
+                untouched.
+              </li>
+            </ul>
+          </div>
+
+          <div className={styles.infoSection}>
+            <h3>Staying up to date</h3>
+            <p>
+              About once an hour Calino checks your server in the background, so an event you add on
+              another device gets to your phone and reminds you even if you haven&apos;t opened
+              Calino since. Nothing is sent anywhere new — it&apos;s the same connection to your own
+              server that the app already uses.
+            </p>
+          </div>
+
+          <div className={styles.infoSection}>
+            <h3>Why it&apos;s in beta</h3>
+            <p>
+              The background check is at the mercy of your phone&apos;s battery settings. Xiaomi,
+              Samsung, OPPO, OnePlus and Huawei devices in particular freeze background apps
+              aggressively, and will silently skip it. If your events seem stale, set Calino to{' '}
+              <strong>No restrictions</strong> in Android&apos;s battery settings for the app.
+            </p>
+            <p>
+              If a mirrored calendar doesn&apos;t appear in your calendar app, it&apos;s usually
+              hidden rather than missing — new calendars often arrive unticked in that app&apos;s
+              own list of calendars to display.
+            </p>
+          </div>
+        </div>
+      </Modal>
 
       <div className={styles.group}>
         <div className={styles.groupLabel}>Tasks</div>

--- a/src/features/settings/components/Settings.module.css
+++ b/src/features/settings/components/Settings.module.css
@@ -1918,6 +1918,41 @@
   box-shadow: none;
 }
 
+/* ── Feature explainer modal ─────────────────────────────────────────── */
+.infoBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ink-2);
+}
+
+.infoBody h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.infoBody p,
+.infoBody ul {
+  margin: 0;
+}
+
+.infoBody ul {
+  padding-left: 1.15em;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.infoSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
 /* Toggle with label text */
 .toggleRow {
   display: flex;

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1,0 +1,140 @@
+/**
+ * Background sync entry point — the page `HeadlessSyncWorker` loads.
+ *
+ * This exists so the calendar mirror can be refreshed while Calino is closed.
+ * The mirror makes Android's calendar provider own reminder alarms, which is
+ * reliable in a way `LocalNotifications` is not, but the provider can only
+ * alarm events it has been given: without a background refresh an event created
+ * on another device never reaches it, and never alerts. This is the other half
+ * of that feature.
+ *
+ * It is deliberately not the app. No React, no stores, no UI — it reads the
+ * state the app persisted, does one CalDAV pass, writes the provider, and says
+ * it is done. See `HeadlessSyncWorker` for why there is no Capacitor here.
+ *
+ * ## Read-only with respect to app state
+ *
+ * Nothing here writes `localStorage`. The foreground app keeps its own
+ * in-memory zustand copy and rehydrates only at startup, so a background write
+ * would race it — either clobbering a change the user just made or being
+ * silently overwritten by the app's next save. The provider is the only thing
+ * this page mutates, and the app reconciles the mirror from its own state when
+ * it next opens, so the two converge.
+ */
+
+import type { Calendar, CalendarEvent } from '@/types'
+import type { CalDAVCalendar } from '@/features/caldav/types'
+import { getHeadlessBridge } from '@/lib/headlessBridge'
+import { getAllAccounts, getCalendarsByAccountId } from '@/features/caldav/sync/accountStorage'
+import { getCredentialById } from '@/features/caldav/client/credentials'
+import { createCalDAVClient } from '@/features/caldav/client/CalDAVClient'
+import { parseICALData } from '@/features/caldav/adapter/iCalendarAdapter'
+import { buildMirrorPayload, MIRROR_PAST_DAYS, MIRROR_FUTURE_DAYS } from '@/lib/calendarMirror'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** Mirrors the app's `zustand/persist` key. Read, never written. */
+function readPersisted<T>(key: string): Partial<T> {
+  try {
+    const raw = localStorage.getItem(key)
+    if (!raw) return {}
+    return ((JSON.parse(raw) as { state?: Partial<T> }).state ?? {}) as Partial<T>
+  } catch {
+    return {}
+  }
+}
+
+interface HeadlessResult {
+  accounts: number
+  calendars: number
+  events: number
+}
+
+/**
+ * Fetches every CalDAV calendar the app has marked visible and writes the
+ * result to the mirror.
+ *
+ * One account failing does not fail the pass: the others still refresh, and the
+ * partial reconcile leaves the failed account's existing rows in place rather
+ * than deleting events it merely could not reach.
+ */
+export async function runHeadlessSync(): Promise<HeadlessResult> {
+  const bridge = getHeadlessBridge()
+  if (!bridge) throw new Error('runHeadlessSync called outside the headless WebView')
+
+  // Visibility and colour live only in the app's store, so it is the authority
+  // on what gets mirrored — the same source the foreground pass uses.
+  const storeCalendars = readPersisted<{ calendars: Calendar[] }>('calino-storage').calendars ?? []
+  const visibleById = new Map(storeCalendars.filter((c) => c.isVisible).map((c) => [c.id, c]))
+  const { defaultReminderMinutes = 15 } = readPersisted<{ defaultReminderMinutes: number }>(
+    'calino-settings'
+  )
+
+  const now = Date.now()
+  const rangeStart = new Date(now - MIRROR_PAST_DAYS * DAY_MS).toISOString()
+  const rangeEnd = new Date(now + MIRROR_FUTURE_DAYS * DAY_MS).toISOString()
+
+  const events: CalendarEvent[] = []
+  const fetched: Calendar[] = []
+  let accountsSynced = 0
+
+  for (const account of getAllAccounts()) {
+    const targets = getCalendarsByAccountId(account.id).filter((calendar: CalDAVCalendar) =>
+      visibleById.has(calendar.id)
+    )
+    if (targets.length === 0) continue
+
+    try {
+      const credentials = await getCredentialById(account.credentialId)
+      if (!credentials) {
+        bridge.log(`Skipping account ${account.name}: credentials are gone`)
+        continue
+      }
+      const client = await createCalDAVClient(account.serverUrl, credentials, account.proxyUrl)
+
+      for (const calendar of targets) {
+        try {
+          const resources = await client.fetchEvents(calendar.url, rangeStart, rangeEnd)
+          for (const resource of resources) {
+            events.push(...parseICALData(resource.data, calendar.id))
+          }
+          fetched.push(visibleById.get(calendar.id)!)
+        } catch (error) {
+          bridge.log(`Calendar ${calendar.name} failed: ${String(error)}`)
+        }
+      }
+      accountsSynced++
+    } catch (error) {
+      bridge.log(`Account ${account.name} failed: ${String(error)}`)
+    }
+  }
+
+  if (fetched.length === 0) {
+    // Writing an empty payload here would be indistinguishable from "the user
+    // deleted everything" — and with nothing fetched we have no evidence of
+    // that. Leave the mirror as the app last left it.
+    bridge.log('No calendars fetched; leaving the mirror untouched')
+    return { accounts: accountsSynced, calendars: 0, events: 0 }
+  }
+
+  const payload = buildMirrorPayload(events, fetched, defaultReminderMinutes)
+  const result = JSON.parse(bridge.mirrorSync(JSON.stringify(payload))) as { error?: string }
+  if (result.error) throw new Error(result.error)
+
+  return { accounts: accountsSynced, calendars: payload.calendars.length, events: payload.events.length }
+}
+
+const bridge = getHeadlessBridge()
+if (bridge) {
+  runHeadlessSync()
+    .then((result) => {
+      bridge.log(
+        `Background sync done: ${result.events} events across ${result.calendars} calendars ` +
+          `from ${result.accounts} account(s)`
+      )
+      bridge.finish('')
+    })
+    .catch((error: unknown) => {
+      bridge.finish(error instanceof Error ? error.message : String(error))
+    })
+}

--- a/src/hooks/__tests__/useCalendarMirror.test.ts
+++ b/src/hooks/__tests__/useCalendarMirror.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useCalendarMirror } from '../useCalendarMirror'
+import { useCalendarMirrorStore } from '@/store/calendarMirrorStore'
+import type { Calendar, CalendarEvent } from '@/types'
+
+const mockSync = vi.fn()
+const mockClear = vi.fn()
+const mockCheckPermission = vi.fn()
+const mockHasCalendarApp = vi.fn()
+
+vi.mock('@/lib/calendarMirror', () => ({
+  isCalendarMirrorSupported: () => true,
+  checkCalendarMirrorPermission: () => mockCheckPermission(),
+  hasCalendarApp: () => mockHasCalendarApp(),
+  syncCalendarMirror: (...args: unknown[]) => mockSync(...args),
+  clearCalendarMirror: () => mockClear(),
+}))
+
+vi.mock('@capacitor/app', () => ({
+  App: { addListener: () => Promise.resolve({ remove: vi.fn() }) },
+}))
+
+let currentEvents: CalendarEvent[] = []
+const currentCalendars: Calendar[] = []
+let currentEnabled = true
+
+vi.mock('@/store/calendarStore', () => ({
+  useCalendarStore: (selector: (s: { events: CalendarEvent[]; calendars: Calendar[] }) => unknown) =>
+    selector({ events: currentEvents, calendars: currentCalendars }),
+}))
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: (
+    selector: (s: { enableCalendarMirror: boolean; defaultReminderMinutes: number }) => unknown
+  ) => selector({ enableCalendarMirror: currentEnabled, defaultReminderMinutes: 15 }),
+}))
+
+function event(id: string): CalendarEvent {
+  return {
+    id,
+    calendarId: 'cal-1',
+    title: id,
+    start: '2026-06-16T09:00:00.000Z',
+    end: '2026-06-16T09:30:00.000Z',
+    isAllDay: false,
+  }
+}
+
+describe('useCalendarMirror', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    currentEvents = [event('a')]
+    currentEnabled = true
+    mockSync.mockReset().mockResolvedValue(undefined)
+    mockClear.mockReset().mockResolvedValue(undefined)
+    mockCheckPermission.mockReset().mockResolvedValue(true)
+    mockHasCalendarApp.mockReset().mockResolvedValue(true)
+    useCalendarMirrorStore.setState({ status: 'off', lastError: null })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reports active once a sync completes', async () => {
+    renderHook(() => useCalendarMirror())
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+    })
+    await waitFor(() => expect(useCalendarMirrorStore.getState().status).toBe('active'))
+  })
+
+  it('reports no-calendar-app when nothing can raise provider reminders', async () => {
+    mockHasCalendarApp.mockResolvedValue(false)
+    renderHook(() => useCalendarMirror())
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+    })
+    await waitFor(() => expect(useCalendarMirrorStore.getState().status).toBe('no-calendar-app'))
+  })
+
+  it('distinguishes a failed write from a missing permission', async () => {
+    mockSync.mockRejectedValue(new Error('provider exploded'))
+    renderHook(() => useCalendarMirror())
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+    })
+    await waitFor(() => {
+      expect(useCalendarMirrorStore.getState().status).toBe('failed')
+      expect(useCalendarMirrorStore.getState().lastError).toBe('provider exploded')
+    })
+  })
+
+  it('records the result of a sync that outlives its effect run', async () => {
+    // The regression: this hook re-runs on every event write, so a CalDAV sync
+    // tears the effect down repeatedly while a mirror pass is still in flight.
+    // Those passes used to complete and then discard their own result, leaving
+    // the status stuck at 'off' — which the settings UI showed as "Syncing…"
+    // forever on any account large enough to keep writing events.
+    let resolveSync: () => void = () => {}
+    mockSync.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSync = resolve
+        })
+    )
+
+    const { rerender } = renderHook(() => useCalendarMirror())
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(mockSync).toHaveBeenCalled()
+
+    // A new event arrives mid-sync, tearing down and re-creating the effect.
+    currentEvents = [event('a'), event('b')]
+    rerender()
+
+    await act(async () => {
+      resolveSync()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(useCalendarMirrorStore.getState().status).toBe('active'))
+  })
+
+  it('tears the mirror down when the setting is turned off', async () => {
+    currentEnabled = false
+    renderHook(() => useCalendarMirror())
+    await waitFor(() => expect(mockClear).toHaveBeenCalled())
+    expect(useCalendarMirrorStore.getState().status).toBe('off')
+  })
+})

--- a/src/hooks/__tests__/useCalendarMirror.test.ts
+++ b/src/hooks/__tests__/useCalendarMirror.test.ts
@@ -8,6 +8,8 @@ const mockSync = vi.fn()
 const mockClear = vi.fn()
 const mockCheckPermission = vi.fn()
 const mockHasCalendarApp = vi.fn()
+const mockScheduleBackgroundSync = vi.fn()
+const mockCancelBackgroundSync = vi.fn()
 
 vi.mock('@/lib/calendarMirror', () => ({
   isCalendarMirrorSupported: () => true,
@@ -15,6 +17,8 @@ vi.mock('@/lib/calendarMirror', () => ({
   hasCalendarApp: () => mockHasCalendarApp(),
   syncCalendarMirror: (...args: unknown[]) => mockSync(...args),
   clearCalendarMirror: () => mockClear(),
+  scheduleBackgroundSync: () => mockScheduleBackgroundSync(),
+  cancelBackgroundSync: () => mockCancelBackgroundSync(),
 }))
 
 vi.mock('@capacitor/app', () => ({
@@ -56,6 +60,8 @@ describe('useCalendarMirror', () => {
     mockClear.mockReset().mockResolvedValue(undefined)
     mockCheckPermission.mockReset().mockResolvedValue(true)
     mockHasCalendarApp.mockReset().mockResolvedValue(true)
+    mockScheduleBackgroundSync.mockReset().mockResolvedValue(undefined)
+    mockCancelBackgroundSync.mockReset().mockResolvedValue(undefined)
     useCalendarMirrorStore.setState({ status: 'off', lastError: null })
   })
 
@@ -129,5 +135,17 @@ describe('useCalendarMirror', () => {
     renderHook(() => useCalendarMirror())
     await waitFor(() => expect(mockClear).toHaveBeenCalled())
     expect(useCalendarMirrorStore.getState().status).toBe('off')
+    // The worker would otherwise keep waking the device to refresh a mirror
+    // that no longer exists.
+    expect(mockCancelBackgroundSync).toHaveBeenCalled()
+    expect(mockScheduleBackgroundSync).not.toHaveBeenCalled()
+  })
+
+  it('starts the background refresh while the mirror is on', async () => {
+    // Without it the mirror only holds what Calino saw in the foreground, so
+    // an event created elsewhere never reaches the provider to be alarmed.
+    renderHook(() => useCalendarMirror())
+    await waitFor(() => expect(mockScheduleBackgroundSync).toHaveBeenCalled())
+    expect(mockCancelBackgroundSync).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/useCalendarMirror.ts
+++ b/src/hooks/useCalendarMirror.ts
@@ -9,6 +9,8 @@ import {
   hasCalendarApp,
   syncCalendarMirror,
   clearCalendarMirror,
+  scheduleBackgroundSync,
+  cancelBackgroundSync,
 } from '@/lib/calendarMirror'
 
 /** Matches the reminder reconcile debounce — a sync stores events one at a
@@ -34,10 +36,24 @@ export function useCalendarMirror(): void {
   const runIdRef = useRef(0)
 
   // Tear down when the setting goes off, so we never leave orphaned calendars
-  // sitting in the user's calendar app.
+  // sitting in the user's calendar app — or an unowned worker still waking the
+  // device to refresh a mirror that no longer exists.
   useEffect(() => {
-    if (!isCalendarMirrorSupported() || enableCalendarMirror) return
+    if (!isCalendarMirrorSupported()) return
+
+    if (enableCalendarMirror) {
+      // The periodic refresh is what keeps the provider alarming events Calino
+      // has never seen in the foreground; without it the mirror is only as
+      // fresh as the last time the app was open.
+      void scheduleBackgroundSync().catch(() => {
+        // A missing background refresh degrades freshness, not correctness, and
+        // every foreground sync re-arms it.
+      })
+      return
+    }
+
     setStatus('off')
+    void cancelBackgroundSync().catch(() => {})
     void clearCalendarMirror().catch(() => {
       // Nothing actionable — the calendars are only reachable via our own
       // account, and the next enable/disable cycle retries.

--- a/src/hooks/useCalendarMirror.ts
+++ b/src/hooks/useCalendarMirror.ts
@@ -1,0 +1,111 @@
+import { useEffect, useRef } from 'react'
+import { App as CapacitorApp } from '@capacitor/app'
+import { useCalendarStore } from '@/store/calendarStore'
+import { useSettingsStore } from '@/store/settingsStore'
+import { useCalendarMirrorStore } from '@/store/calendarMirrorStore'
+import {
+  isCalendarMirrorSupported,
+  checkCalendarMirrorPermission,
+  hasCalendarApp,
+  syncCalendarMirror,
+  clearCalendarMirror,
+} from '@/lib/calendarMirror'
+
+/** Matches the reminder reconcile debounce — a sync stores events one at a
+ * time, and each mirror pass is a full diff across the provider. */
+const MIRROR_DEBOUNCE_MS = 1500
+
+/**
+ * Keeps Android's calendar provider in step with Calino's events while the
+ * mirror setting is on, and tears the mirror down when it is turned off.
+ *
+ * Mirroring the store's raw `events` (not the expanded occurrences
+ * `useNotifications` works from) is deliberate: recurring masters carry their
+ * RRULE straight through to the provider, which expands them itself.
+ */
+export function useCalendarMirror(): void {
+  const events = useCalendarStore((state) => state.events)
+  const calendars = useCalendarStore((state) => state.calendars)
+  const enableCalendarMirror = useSettingsStore((state) => state.enableCalendarMirror)
+  const defaultReminderMinutes = useSettingsStore((state) => state.defaultReminderMinutes)
+  const setStatus = useCalendarMirrorStore((state) => state.setStatus)
+  const setLastError = useCalendarMirrorStore((state) => state.setLastError)
+  // Survives effect re-runs, unlike a per-effect flag — see runSync.
+  const runIdRef = useRef(0)
+
+  // Tear down when the setting goes off, so we never leave orphaned calendars
+  // sitting in the user's calendar app.
+  useEffect(() => {
+    if (!isCalendarMirrorSupported() || enableCalendarMirror) return
+    setStatus('off')
+    void clearCalendarMirror().catch(() => {
+      // Nothing actionable — the calendars are only reachable via our own
+      // account, and the next enable/disable cycle retries.
+    })
+  }, [enableCalendarMirror, setStatus])
+
+  useEffect(() => {
+    if (!isCalendarMirrorSupported() || !enableCalendarMirror) return
+
+    let cancelled = false
+    let debounceId: ReturnType<typeof setTimeout> | undefined
+
+    const runSync = async (): Promise<void> => {
+      // Only the newest run may record a status, so a slow pass can't clobber
+      // a fresher result. Deliberately NOT keyed off the effect's `cancelled`
+      // flag: this effect re-runs on every event write, so a CalDAV sync tears
+      // it down repeatedly while a mirror pass is still in flight. Gating the
+      // status write on `cancelled` meant those passes completed successfully
+      // and then threw their result away, leaving the status stuck at its
+      // initial value forever on any account big enough to keep writing.
+      const runId = ++runIdRef.current
+      const isStale = (): boolean => runIdRef.current !== runId
+
+      // The app setting being on doesn't mean the OS grant survived; a
+      // reinstall or a manual revoke resets it independently.
+      const granted = await checkCalendarMirrorPermission()
+      if (isStale()) return
+      if (!granted) {
+        setStatus('denied')
+        return
+      }
+
+      try {
+        await syncCalendarMirror(events, calendars, defaultReminderMinutes)
+        if (isStale()) return
+        setLastError(null)
+        // Checked after a successful sync rather than once at startup: the
+        // user can install or uninstall a calendar app at any time, and this
+        // decides whether local notifications stay on.
+        const calendarAppPresent = await hasCalendarApp()
+        if (isStale()) return
+        setStatus(calendarAppPresent ? 'active' : 'no-calendar-app')
+      } catch (error) {
+        if (isStale()) return
+        // Fall back to Calino's own notifications rather than trusting a
+        // mirror we failed to write.
+        setStatus('failed')
+        setLastError(error instanceof Error ? error.message : String(error))
+      }
+    }
+
+    const scheduleSync = (): void => {
+      clearTimeout(debounceId)
+      debounceId = setTimeout(() => {
+        if (!cancelled) void runSync()
+      }, MIRROR_DEBOUNCE_MS)
+    }
+
+    scheduleSync()
+
+    const appStateListenerPromise = CapacitorApp.addListener('appStateChange', ({ isActive }) => {
+      if (isActive && !cancelled) void runSync()
+    })
+
+    return () => {
+      cancelled = true
+      clearTimeout(debounceId)
+      void appStateListenerPromise.then((handle) => handle.remove())
+    }
+  }, [events, calendars, enableCalendarMirror, defaultReminderMinutes, setStatus, setLastError])
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -15,7 +15,9 @@ import {
   reconcileNativeReminders,
   listenForReminderActions,
   checkNativeReminderPermission,
+  cancelAllNativeReminders,
 } from '@/lib/nativeReminders'
+import { useCalendarMirrorStore, mirrorOwnsReminders } from '@/store/calendarMirrorStore'
 import { parseISO, isWithinInterval, addMinutes, addHours, addDays, isAfter } from 'date-fns'
 import { toast } from 'sonner'
 import type { CalendarEvent } from '@/types'
@@ -61,6 +63,11 @@ export function useNotifications(): void {
   const reminderEvents = useReminderOccurrences(events)
   const enableNotifications = useSettingsStore((state) => state.enableDesktopNotifications)
   const defaultReminderMinutes = useSettingsStore((state) => state.defaultReminderMinutes)
+  // When the Android calendar mirror is active the OS alarms our events off
+  // CalendarContract, which works with the app closed — strictly better than
+  // what we can schedule ourselves. Standing down avoids double notifications.
+  const mirrorStatus = useCalendarMirrorStore((state) => state.status)
+  const providerOwnsReminders = mirrorOwnsReminders(mirrorStatus)
   // Track reminder ID → scheduled trigger timestamp so we can re-fire
   // when the event is edited (trigger time changes).
   const shownReminders = useRef<Map<string, number>>(new Map())
@@ -81,6 +88,14 @@ export function useNotifications(): void {
     // independent of the app's own persisted settings, and schedule() throws
     // if it's not granted yet. Check for real before ever calling it.
     const reconcileIfPermitted = async (): Promise<void> => {
+      // With the mirror active the calendar provider alarms these events, so
+      // scheduling our own would double-notify. Drop what we already queued
+      // (this also covers the moment the mirror first becomes active) and
+      // leave the queue empty until it stops being active.
+      if (providerOwnsReminders) {
+        await cancelAllNativeReminders()
+        return
+      }
       const granted = await checkNativeReminderPermission()
       if (granted && !cancelled)
         await reconcileNativeReminders(reminderEvents, defaultReminderMinutes)
@@ -110,7 +125,7 @@ export function useNotifications(): void {
       removeListener()
       void appStateListenerPromise.then((handle) => handle.remove())
     }
-  }, [reminderEvents, enableNotifications, defaultReminderMinutes])
+  }, [reminderEvents, enableNotifications, defaultReminderMinutes, providerOwnsReminders])
 
   useEffect(() => {
     prevEnabledRef.current = enableNotifications

--- a/src/lib/__tests__/calendarMirror.test.ts
+++ b/src/lib/__tests__/calendarMirror.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildMirrorPayload,
+  hashPayload,
+  toDuration,
+  toBasicFormat,
+  type MirrorEventPayload,
+} from '../calendarMirror'
+import type { Calendar, CalendarEvent } from '@/types'
+
+const NOW = new Date('2026-06-15T12:00:00.000Z')
+
+const calendars: Calendar[] = [
+  {
+    id: 'cal-1',
+    name: 'Personal',
+    color: '#3b82f6',
+    isVisible: true,
+    isDefault: true,
+    showTasksInViews: true,
+  },
+  {
+    id: 'cal-hidden',
+    name: 'Hidden',
+    color: '#ef4444',
+    isVisible: false,
+    isDefault: false,
+    showTasksInViews: true,
+  },
+]
+
+function event(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: 'evt-1',
+    calendarId: 'cal-1',
+    title: 'Standup',
+    start: '2026-06-16T09:00:00.000Z',
+    end: '2026-06-16T09:30:00.000Z',
+    isAllDay: false,
+    ...overrides,
+  }
+}
+
+function build(events: CalendarEvent[]): ReturnType<typeof buildMirrorPayload> {
+  return buildMirrorPayload(events, calendars, 15, NOW)
+}
+
+describe('toDuration', () => {
+  it('emits seconds for timed events', () => {
+    expect(toDuration(0, 90 * 60 * 1000, false)).toBe('PT5400S')
+  })
+
+  it('emits whole days for all-day events so occurrences stay all-day', () => {
+    expect(toDuration(0, 2 * 24 * 60 * 60 * 1000, true)).toBe('P2D')
+  })
+
+  it('never emits a zero-day all-day duration', () => {
+    expect(toDuration(0, 0, true)).toBe('P1D')
+  })
+})
+
+describe('toBasicFormat', () => {
+  it('emits date-only for all-day exclusions', () => {
+    expect(toBasicFormat('2026-06-16T00:00:00.000Z', true)).toBe('20260616')
+  })
+
+  it('emits UTC timestamps for timed exclusions', () => {
+    expect(toBasicFormat('2026-06-16T09:00:00.000Z', false)).toBe('20260616T090000Z')
+  })
+})
+
+describe('hashPayload', () => {
+  const base: Omit<MirrorEventPayload, 'hash'> = {
+    id: 'evt-1',
+    calendarId: 'cal-1',
+    title: 'Standup',
+    start: 0,
+    end: 1000,
+    allDay: false,
+    timezone: 'UTC',
+    reminders: [15],
+  }
+
+  it('is stable across calls', () => {
+    expect(hashPayload(base)).toBe(hashPayload(base))
+  })
+
+  it('changes when a mirrored field changes', () => {
+    expect(hashPayload({ ...base, title: 'Retro' })).not.toBe(hashPayload(base))
+    expect(hashPayload({ ...base, reminders: [10] })).not.toBe(hashPayload(base))
+  })
+
+  it('ignores the id, which is carried separately as the sync key', () => {
+    expect(hashPayload({ ...base, id: 'evt-2' })).toBe(hashPayload(base))
+  })
+})
+
+describe('buildMirrorPayload', () => {
+  it('mirrors only visible calendars', () => {
+    const result = build([event(), event({ id: 'evt-2', calendarId: 'cal-hidden' })])
+    expect(result.calendars.map((c) => c.id)).toEqual(['cal-1'])
+    expect(result.events.map((e) => e.id)).toEqual(['evt-1'])
+  })
+
+  it('skips tasks and journals, which the provider has no table for', () => {
+    const result = build([
+      event({ id: 'task', type: 'task' }),
+      event({ id: 'journal', type: 'journal' }),
+      event({ id: 'plain', type: 'event' }),
+    ])
+    expect(result.events.map((e) => e.id)).toEqual(['plain'])
+  })
+
+  it('anchors all-day events to midnight UTC with a UTC timezone', () => {
+    const [mirrored] = build([
+      event({ isAllDay: true, start: '2026-06-16T00:00:00.000Z', end: '2026-06-17T00:00:00.000Z' }),
+    ]).events
+    expect(mirrored.start).toBe(Date.UTC(2026, 5, 16))
+    expect(mirrored.timezone).toBe('UTC')
+    expect(mirrored.allDay).toBe(true)
+  })
+
+  it('carries a raw RRULE through with a DURATION instead of an end', () => {
+    const [mirrored] = build([event({ rruleString: 'FREQ=WEEKLY;BYDAY=MO' })]).events
+    expect(mirrored.rrule).toBe('FREQ=WEEKLY;BYDAY=MO')
+    // The provider rejects a recurring event that carries DTEND.
+    expect(mirrored.duration).toBe('PT1800S')
+  })
+
+  it('derives an RRULE from the structured recurrence when there is no raw one', () => {
+    const [mirrored] = build([
+      event({ recurrence: { frequency: 'daily', interval: 2 } }),
+    ]).events
+    expect(mirrored.rrule).toContain('FREQ=DAILY')
+    expect(mirrored.rrule).toContain('INTERVAL=2')
+  })
+
+  it('excludes detached occurrences from the master and mirrors them standalone', () => {
+    const result = build([
+      event({ id: 'master', uid: 'uid-1', rruleString: 'FREQ=WEEKLY' }),
+      event({
+        id: 'detached',
+        uid: 'uid-1',
+        recurrenceId: '2026-06-23T09:00:00.000Z',
+        recurrenceMasterId: 'uid-1',
+        start: '2026-06-23T14:00:00.000Z',
+        end: '2026-06-23T15:00:00.000Z',
+      }),
+    ])
+
+    const master = result.events.find((e) => e.id === 'master')
+    const detached = result.events.find((e) => e.id === 'detached')
+
+    expect(master?.exdate).toBe('20260623T090000Z')
+    // The moved occurrence is a plain event, not a provider exception row.
+    expect(detached?.rrule).toBeUndefined()
+    expect(detached?.start).toBe(new Date('2026-06-23T14:00:00.000Z').getTime())
+  })
+
+  it('merges explicit exclusions with detached-occurrence exclusions', () => {
+    const result = build([
+      event({
+        id: 'master',
+        uid: 'uid-1',
+        rruleString: 'FREQ=WEEKLY',
+        excludedDates: ['2026-06-30T09:00:00.000Z'],
+      }),
+      event({
+        id: 'detached',
+        uid: 'uid-1',
+        recurrenceId: '2026-06-23T09:00:00.000Z',
+        recurrenceMasterId: 'uid-1',
+      }),
+    ])
+    expect(result.events.find((e) => e.id === 'master')?.exdate).toBe(
+      '20260630T090000Z,20260623T090000Z'
+    )
+  })
+
+  it('drops cancelled occurrences, which EXDATE already covers', () => {
+    const result = build([
+      event({ id: 'cancelled', recurrenceId: '2026-06-23T09:00:00.000Z', eventStatus: 'CANCELLED' }),
+    ])
+    expect(result.events).toHaveLength(0)
+  })
+
+  it('bounds one-off events to the mirror window but never bounds a series', () => {
+    const result = build([
+      event({ id: 'ancient', start: '2010-01-01T09:00:00.000Z', end: '2010-01-01T10:00:00.000Z' }),
+      event({ id: 'distant', start: '2040-01-01T09:00:00.000Z', end: '2040-01-01T10:00:00.000Z' }),
+      event({
+        id: 'old-series',
+        start: '2010-01-01T09:00:00.000Z',
+        end: '2010-01-01T10:00:00.000Z',
+        rruleString: 'FREQ=WEEKLY',
+      }),
+    ])
+    expect(result.events.map((e) => e.id)).toEqual(['old-series'])
+  })
+
+  it('falls back to the default reminder and drops email alarms', () => {
+    const [withDefault] = build([event()]).events
+    expect(withDefault.reminders).toEqual([15])
+
+    const [withExplicit] = build([
+      event({
+        reminders: [
+          { id: 'a', minutesBefore: 30, method: 'popup' },
+          { id: 'b', minutesBefore: 60, method: 'email' },
+        ],
+      }),
+    ]).events
+    expect(withExplicit.reminders).toEqual([30])
+  })
+
+  it('maps transparency to the provider availability the native side expects', () => {
+    const [free] = build([event({ transparency: 'transparent' })]).events
+    expect(free.transparency).toBe('transparent')
+  })
+})

--- a/src/lib/calendarMirror.ts
+++ b/src/lib/calendarMirror.ts
@@ -1,0 +1,277 @@
+import { registerPlugin, Capacitor } from '@capacitor/core'
+import type { Calendar, CalendarEvent } from '@/types'
+import { buildRRuleString } from './recurrence'
+import { getEffectiveReminders } from './notifications'
+
+/**
+ * One-way, read-only export of Calino's events into Android's calendar
+ * provider (see `android/.../CalendarMirrorPlugin.java`).
+ *
+ * The point is reminder reliability: `@capacitor/local-notifications` can only
+ * schedule while the app is alive, so an event created on another device never
+ * alerts until Calino next opens. Rows in `CalendarContract` are alarmed by the
+ * OS regardless. The mirror also makes events visible to calendar widgets,
+ * Wear OS and Android Auto, none of which can see IndexedDB.
+ *
+ * Nothing flows back — Calino remains the only writer, and the mirrored
+ * calendars are created read-only.
+ */
+
+export interface MirrorCalendarPayload {
+  id: string
+  name: string
+  color: string
+}
+
+export interface MirrorEventPayload {
+  id: string
+  calendarId: string
+  /** Content hash; lets the native side skip events that did not change. */
+  hash: string
+  title: string
+  description?: string
+  location?: string
+  /** Epoch millis. For all-day events, midnight UTC on the event's date. */
+  start: number
+  /** Epoch millis. Ignored by the native side when `rrule` is set. */
+  end: number
+  allDay: boolean
+  timezone: string
+  transparency?: string
+  rrule?: string
+  /** RFC 5545 DURATION; the provider requires it instead of DTEND on a series. */
+  duration?: string
+  /** Comma-separated basic-format timestamps. */
+  exdate?: string
+  /** Minutes before start, one per reminder. */
+  reminders: number[]
+}
+
+interface CalendarMirrorPlugin {
+  checkCalendarPermission(): Promise<{ granted: boolean }>
+  requestCalendarPermission(): Promise<{ granted: boolean }>
+  hasCalendarApp(): Promise<{ present: boolean }>
+  sync(options: {
+    calendars: MirrorCalendarPayload[]
+    events: MirrorEventPayload[]
+  }): Promise<{ calendars: number; written: number; removed: number }>
+  clear(): Promise<{ removed?: number }>
+}
+
+const CalendarMirror = registerPlugin<CalendarMirrorPlugin>('CalendarMirror')
+
+/**
+ * How much of the timeline non-recurring events are mirrored for. Recurring
+ * series are always mirrored whole — the provider expands them itself, so
+ * there is nothing to bound.
+ *
+ * Past events are kept in range because widgets and Auto show "earlier today",
+ * and because a year of history is what makes the mirrored calendar useful to
+ * browse in another app rather than looking mysteriously empty.
+ */
+const MIRROR_PAST_DAYS = 365
+const MIRROR_FUTURE_DAYS = 730
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export function isCalendarMirrorSupported(): boolean {
+  return Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'android'
+}
+
+export async function checkCalendarMirrorPermission(): Promise<boolean> {
+  if (!isCalendarMirrorSupported()) return false
+  const { granted } = await CalendarMirror.checkCalendarPermission()
+  return granted
+}
+
+export async function requestCalendarMirrorPermission(): Promise<boolean> {
+  if (!isCalendarMirrorSupported()) return false
+  const { granted } = await CalendarMirror.requestCalendarPermission()
+  return granted
+}
+
+/**
+ * Whether a calendar app is installed. The provider stores reminders but does
+ * not post notifications for them — a calendar app does, off the provider's
+ * broadcast. With none installed, mirrored reminders would fire nothing, so
+ * callers must keep local notifications in that case.
+ */
+export async function hasCalendarApp(): Promise<boolean> {
+  if (!isCalendarMirrorSupported()) return false
+  const { present } = await CalendarMirror.hasCalendarApp()
+  return present
+}
+
+export async function clearCalendarMirror(): Promise<void> {
+  if (!isCalendarMirrorSupported()) return
+  await CalendarMirror.clear()
+}
+
+// ------------------------------------------------------------------ mapping
+
+/** Midnight UTC on the calendar date an ISO string names, per the provider's
+ * all-day contract (DTSTART at UTC midnight, EVENT_TIMEZONE "UTC"). */
+function allDayEpoch(iso: string): number {
+  const [y, m, d] = iso.split('T')[0].split('-').map(Number)
+  return Date.UTC(y, m - 1, d)
+}
+
+function eventStartMs(event: CalendarEvent): number {
+  return event.isAllDay ? allDayEpoch(event.start) : new Date(event.start).getTime()
+}
+
+function eventEndMs(event: CalendarEvent): number {
+  return event.isAllDay ? allDayEpoch(event.end) : new Date(event.end).getTime()
+}
+
+/** RFC 5545 DURATION. All-day series use whole days so the provider keeps
+ * them all-day across occurrences; timed series use seconds. */
+export function toDuration(startMs: number, endMs: number, allDay: boolean): string {
+  const ms = Math.max(endMs - startMs, allDay ? DAY_MS : 0)
+  if (allDay) return `P${Math.max(Math.round(ms / DAY_MS), 1)}D`
+  return `PT${Math.max(Math.round(ms / 1000), 0)}S`
+}
+
+/** Basic-format timestamp for EXDATE: `yyyyMMdd` all-day, `yyyyMMddTHHmmssZ`
+ * otherwise. */
+export function toBasicFormat(iso: string, allDay: boolean): string {
+  if (allDay) return iso.split('T')[0].replace(/-/g, '')
+  return `${new Date(iso).toISOString().replace(/[-:]/g, '').split('.')[0]}Z`
+}
+
+/** Order-independent, stable over the fields we actually write, so an event
+ * whose untouched fields get reserialized does not churn the provider. */
+export function hashPayload(payload: Omit<MirrorEventPayload, 'hash'>): string {
+  const source = JSON.stringify([
+    payload.calendarId,
+    payload.title,
+    payload.description ?? '',
+    payload.location ?? '',
+    payload.start,
+    payload.end,
+    payload.allDay,
+    payload.timezone,
+    payload.transparency ?? '',
+    payload.rrule ?? '',
+    payload.duration ?? '',
+    payload.exdate ?? '',
+    payload.reminders,
+  ])
+  // FNV-1a, 32-bit. Collisions only cost a missed update on an event whose
+  // content changed to another value hashing identically — vanishingly rare,
+  // and self-corrects on the next edit.
+  let hash = 0x811c9dc5
+  for (let i = 0; i < source.length; i++) {
+    hash ^= source.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16)
+}
+
+function rruleFor(event: CalendarEvent): string | undefined {
+  if (event.rruleString) return event.rruleString
+  if (event.recurrence) return buildRRuleString({ ...event.recurrence, isAllDay: event.isAllDay })
+  return undefined
+}
+
+/**
+ * Maps store events to mirror payloads.
+ *
+ * Detached recurrence instances are flattened rather than expressed with the
+ * provider's exception model: each detached occurrence is mirrored as a plain
+ * standalone event, and its RECURRENCE-ID is added to the master's EXDATE so
+ * the series does not also render an occurrence in that slot. This keeps us
+ * clear of ORIGINAL_INSTANCE_TIME, which is the fiddliest corner of
+ * CalendarContract and buys nothing for a read-only mirror.
+ */
+export function buildMirrorPayload(
+  events: CalendarEvent[],
+  calendars: Calendar[],
+  defaultReminderMinutes: number,
+  now: Date = new Date()
+): { calendars: MirrorCalendarPayload[]; events: MirrorEventPayload[] } {
+  const mirroredCalendars = calendars
+    .filter((calendar) => calendar.isVisible)
+    .map((calendar) => ({ id: calendar.id, name: calendar.name, color: calendar.color }))
+  const calendarIds = new Set(mirroredCalendars.map((calendar) => calendar.id))
+
+  const windowStart = now.getTime() - MIRROR_PAST_DAYS * DAY_MS
+  const windowEnd = now.getTime() + MIRROR_FUTURE_DAYS * DAY_MS
+  const deviceTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+  // RECURRENCE-IDs of detached occurrences, grouped by the master they detach
+  // from, so masters can exclude those slots.
+  const detachedByMaster = new Map<string, string[]>()
+  for (const event of events) {
+    if (!event.recurrenceId) continue
+    const masterId = event.recurrenceMasterId ?? event.uid
+    if (!masterId) continue
+    const existing = detachedByMaster.get(masterId)
+    if (existing) existing.push(event.recurrenceId)
+    else detachedByMaster.set(masterId, [event.recurrenceId])
+  }
+
+  const payloads: MirrorEventPayload[] = []
+
+  for (const event of events) {
+    // The provider has no task or journal table; VTODO/VJOURNAL stay in Calino.
+    if (event.type && event.type !== 'event') continue
+    if (!calendarIds.has(event.calendarId)) continue
+    // Cancelled detached occurrences exist only to blank out a slot, which
+    // EXDATE already handles.
+    if (event.eventStatus === 'CANCELLED') continue
+
+    const rrule = event.recurrenceId ? undefined : rruleFor(event)
+    const start = eventStartMs(event)
+    const end = eventEndMs(event)
+
+    // Bounded window applies to one-off events only; a series can extend
+    // arbitrarily far and is cheap for the provider to expand.
+    if (!rrule && (end < windowStart || start > windowEnd)) continue
+
+    const exdates = [
+      ...(event.excludedDates ?? []),
+      ...(rrule ? (detachedByMaster.get(event.uid ?? event.id) ?? []) : []),
+    ]
+
+    const base: Omit<MirrorEventPayload, 'hash'> = {
+      id: event.id,
+      calendarId: event.calendarId,
+      title: event.title || '(No title)',
+      description: event.description,
+      location: event.location,
+      start,
+      end,
+      allDay: event.isAllDay,
+      // The provider's all-day contract is UTC-anchored; timed events keep
+      // their originating TZID so wall-clock survives a device timezone change.
+      timezone: event.isAllDay ? 'UTC' : (event.timezone ?? deviceTimezone),
+      transparency: event.transparency,
+      rrule,
+      duration: rrule ? toDuration(start, end, event.isAllDay) : undefined,
+      exdate:
+        rrule && exdates.length > 0
+          ? exdates.map((iso) => toBasicFormat(iso, event.isAllDay)).join(',')
+          : undefined,
+      reminders: getEffectiveReminders(event, defaultReminderMinutes)
+        // METHOD_ALERT is the only method we register on the calendar; an
+        // email VALARM is the server's job, not the phone's.
+        .filter((reminder) => reminder.method !== 'email')
+        .map((reminder) => reminder.minutesBefore),
+    }
+
+    payloads.push({ ...base, hash: hashPayload(base) })
+  }
+
+  return { calendars: mirroredCalendars, events: payloads }
+}
+
+export async function syncCalendarMirror(
+  events: CalendarEvent[],
+  calendars: Calendar[],
+  defaultReminderMinutes: number
+): Promise<void> {
+  if (!isCalendarMirrorSupported()) return
+  const payload = buildMirrorPayload(events, calendars, defaultReminderMinutes)
+  await CalendarMirror.sync(payload)
+}

--- a/src/lib/calendarMirror.ts
+++ b/src/lib/calendarMirror.ts
@@ -56,6 +56,8 @@ interface CalendarMirrorPlugin {
     events: MirrorEventPayload[]
   }): Promise<{ calendars: number; written: number; removed: number }>
   clear(): Promise<{ removed?: number }>
+  scheduleBackgroundSync(options?: { intervalMinutes?: number }): Promise<void>
+  cancelBackgroundSync(): Promise<void>
 }
 
 const CalendarMirror = registerPlugin<CalendarMirrorPlugin>('CalendarMirror')
@@ -69,8 +71,8 @@ const CalendarMirror = registerPlugin<CalendarMirrorPlugin>('CalendarMirror')
  * and because a year of history is what makes the mirrored calendar useful to
  * browse in another app rather than looking mysteriously empty.
  */
-const MIRROR_PAST_DAYS = 365
-const MIRROR_FUTURE_DAYS = 730
+export const MIRROR_PAST_DAYS = 365
+export const MIRROR_FUTURE_DAYS = 730
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -105,6 +107,23 @@ export async function hasCalendarApp(): Promise<boolean> {
 export async function clearCalendarMirror(): Promise<void> {
   if (!isCalendarMirrorSupported()) return
   await CalendarMirror.clear()
+}
+
+/**
+ * Starts the periodic background refresh (`HeadlessSyncWorker`).
+ *
+ * Without it the mirror only holds what Calino saw while it was open, so an
+ * event created on another device never reaches the provider and never alarms
+ * — which would leave the mirror solving only half the problem it exists for.
+ */
+export async function scheduleBackgroundSync(): Promise<void> {
+  if (!isCalendarMirrorSupported()) return
+  await CalendarMirror.scheduleBackgroundSync()
+}
+
+export async function cancelBackgroundSync(): Promise<void> {
+  if (!isCalendarMirrorSupported()) return
+  await CalendarMirror.cancelBackgroundSync()
 }
 
 // ------------------------------------------------------------------ mapping

--- a/src/lib/headlessBridge.ts
+++ b/src/lib/headlessBridge.ts
@@ -1,0 +1,32 @@
+/**
+ * The native interface available to the background sync page, and only there.
+ *
+ * `HeadlessSyncWorker` runs Calino's real CalDAV engine in a bare WebView so
+ * the mirror can be refreshed while the app is closed. That WebView has no
+ * Capacitor bridge — `Bridge` requires an Activity and a worker has none — so
+ * the two native capabilities the sync needs are injected as a plain
+ * `@JavascriptInterface` object instead. Everything here is synchronous
+ * because that is what `addJavascriptInterface` gives us; the calls run on the
+ * WebView's JS thread with nothing else to block.
+ *
+ * Present only on `headless.html`. In the normal app this is undefined and the
+ * Capacitor plugins are used instead.
+ */
+export interface HeadlessBridge {
+  /** One DAV request. Returns JSON: `{ok, response}` or `{ok: false, error}`. */
+  davRequest(optionsJson: string): string
+  /** Reconciles the calendar provider. Returns JSON counts, or `{error}`. */
+  mirrorSync(payloadJson: string): string
+  /** Writes to logcat under the `CalinoHeadlessSync` tag. */
+  log(message: string): void
+  /** Ends the pass. A non-empty string marks it failed, so the worker retries. */
+  finish(error: string): void
+}
+
+export function getHeadlessBridge(): HeadlessBridge | undefined {
+  return (globalThis as { CalinoHeadless?: HeadlessBridge }).CalinoHeadless
+}
+
+export function isHeadless(): boolean {
+  return getHeadlessBridge() !== undefined
+}

--- a/src/lib/nativeReminders.ts
+++ b/src/lib/nativeReminders.ts
@@ -94,6 +94,22 @@ export async function reconcileNativeReminders(
   }
 }
 
+/**
+ * Drops every notification we have scheduled. Used when the Android calendar
+ * mirror takes over reminder duty, so the same event can't alert twice.
+ *
+ * Like `reconcileNativeReminders`, this clears pending snoozes too — they are
+ * scheduled through the same queue and there is no reason to keep a snooze
+ * alive for a reminder the OS is now going to raise itself.
+ */
+export async function cancelAllNativeReminders(): Promise<void> {
+  const pending = await LocalNotifications.getPending()
+  if (pending.notifications.length === 0) return
+  await LocalNotifications.cancel({
+    notifications: pending.notifications.map((n) => ({ id: n.id })),
+  })
+}
+
 export function listenForReminderActions(): () => void {
   const listenerPromise = LocalNotifications.addListener(
     'localNotificationActionPerformed',

--- a/src/lib/webFetch.ts
+++ b/src/lib/webFetch.ts
@@ -1,4 +1,5 @@
 import { Capacitor, registerPlugin } from '@capacitor/core'
+import { getHeadlessBridge, isHeadless } from './headlessBridge'
 
 /**
  * The fetch used for all CalDAV/CardDAV traffic.
@@ -59,7 +60,33 @@ function abortError(): Error {
   return new DOMException('The operation was aborted.', 'AbortError')
 }
 
-async function nativeFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+/** Same shape as DavHttpPlugin.request, whichever side performs it. */
+type DavTransport = (options: {
+  url: string
+  method: string
+  headers: Record<string, string>
+  body?: string
+}) => Promise<DavHttpResponse>
+
+/**
+ * The background sync page has no Capacitor bridge, so DAV traffic goes over
+ * the worker's `@JavascriptInterface` instead. Same OkHttp call underneath —
+ * both land in `DavHttp.java`.
+ */
+const headlessTransport: DavTransport = async (options) => {
+  const bridge = getHeadlessBridge()!
+  const result = JSON.parse(bridge.davRequest(JSON.stringify(options))) as
+    | { ok: true; response: DavHttpResponse }
+    | { ok: false; error: string }
+  if (!result.ok) throw new Error(result.error)
+  return result.response
+}
+
+async function nativeFetch(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  transport: DavTransport
+): Promise<Response> {
   // Normalize through Request so a Request input, a URL, and init overrides all
   // collapse to one representation — same as the platform would.
   const request = new Request(input, init)
@@ -71,7 +98,7 @@ async function nativeFetch(input: RequestInfo | URL, init?: RequestInit): Promis
   const body =
     request.method === 'GET' || request.method === 'HEAD' ? undefined : await request.text()
 
-  const pending = DavHttp.request({
+  const pending = transport({
     url: request.url,
     method: request.method,
     headers,
@@ -81,7 +108,16 @@ async function nativeFetch(input: RequestInfo | URL, init?: RequestInit): Promis
   // Callers wrap requests in AbortController timeouts. The native call can't be
   // cancelled mid-flight (it has its own timeout), but the caller must still see
   // an AbortError on schedule rather than waiting on the longer native timeout.
-  const result = await (init?.signal ? raceAbort(pending, init.signal) : pending)
+  //
+  // Except in the background worker, where honouring the signal is worse than
+  // useless. That transport is synchronous, so the timer physically cannot fire
+  // while a request is in flight — but Android freezes background processes,
+  // and a frozen-then-thawed worker fires every elapsed timer at once,
+  // aborting requests that were about to succeed. Observed on MIUI: a pass
+  // frozen for nine minutes failed every account with "timeout" the instant it
+  // resumed. Nothing is waiting on this page, and OkHttp has its own timeout.
+  const abortable = init?.signal && !isHeadless()
+  const result = await (abortable ? raceAbort(pending, init.signal!) : pending)
 
   // 204/304 must not carry a body or the Response constructor throws.
   const hasBody = result.status !== 204 && result.status !== 304
@@ -98,8 +134,13 @@ async function nativeFetch(input: RequestInfo | URL, init?: RequestInit): Promis
 }
 
 export function webFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  // Checked before the Capacitor test: the headless page is a plain WebView, so
+  // `isNativePlatform()` is false there even though we very much are on device.
+  if (isHeadless()) {
+    return nativeFetch(input, init, headlessTransport)
+  }
   if (Capacitor.isNativePlatform()) {
-    return nativeFetch(input, init)
+    return nativeFetch(input, init, (options) => DavHttp.request(options))
   }
   return unpatchedFetch()(input, init)
 }

--- a/src/store/calendarMirrorStore.ts
+++ b/src/store/calendarMirrorStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand'
+
+/**
+ * Runtime (not persisted) state of the Android calendar mirror.
+ *
+ * It exists so `useNotifications` can tell whether the OS has taken over
+ * reminder duty. The user's setting alone can't answer that: the mirror only
+ * really owns reminders once the calendar permission is granted *and* a
+ * calendar app is installed to post the provider's alerts. Persisting any of
+ * this would be wrong — permissions and installed apps change behind our back.
+ */
+export type CalendarMirrorStatus =
+  /** Off by setting, or not an Android build. */
+  | 'off'
+  /** On, permission granted, a calendar app will raise the alerts. */
+  | 'active'
+  /** On and mirroring, but nothing on the device posts calendar reminders,
+   *  so Calino must keep scheduling its own notifications. */
+  | 'no-calendar-app'
+  /** On by setting, but the OS permission is not granted. */
+  | 'denied'
+  /** On and permitted, but the last write to the provider failed. Distinct
+   *  from 'denied' so the UI doesn't send the user to fix a permission that
+   *  was never the problem; `lastError` carries the detail. */
+  | 'failed'
+
+interface CalendarMirrorState {
+  status: CalendarMirrorStatus
+  lastError: string | null
+  setStatus: (status: CalendarMirrorStatus) => void
+  setLastError: (error: string | null) => void
+}
+
+export const useCalendarMirrorStore = create<CalendarMirrorState>((set) => ({
+  status: 'off',
+  lastError: null,
+  setStatus: (status) => set({ status }),
+  setLastError: (lastError) => set({ lastError }),
+}))
+
+/**
+ * Whether the calendar provider is responsible for firing reminders, meaning
+ * Calino should stand down its own scheduling to avoid double notifications.
+ */
+export function mirrorOwnsReminders(status: CalendarMirrorStatus): boolean {
+  return status === 'active'
+}

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -114,6 +114,9 @@ const DEFAULT_SETTINGS: UserSettings = {
   defaultReminderMinutes: 15,
   defaultEventColor: DEFAULT_CALENDAR_COLOR,
   enableDesktopNotifications: true,
+  // Off by default: it needs a runtime calendar permission, so it has to be a
+  // deliberate opt-in rather than something a user discovers via a prompt.
+  enableCalendarMirror: false,
   enableSoundAlerts: false,
   enableHaptics: false,
   conflictResolution: 'server-wins',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -301,6 +301,9 @@ export interface UserSettings {
   defaultReminderMinutes: number
   defaultEventColor: string
   enableDesktopNotifications: boolean
+  /** Android only: mirror events into the OS calendar provider so the system
+   *  fires reminders and other apps (widgets, Wear OS, Auto) can see them. */
+  enableCalendarMirror: boolean
   enableSoundAlerts: boolean
   enableHaptics: boolean
   conflictResolution: 'server-wins' | 'local-wins' | 'ask'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,6 +65,18 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    rollupOptions: {
+      // Second entry for the Android background sync worker, which loads
+      // headless.html in an offscreen WebView at the same origin as the app so
+      // it can read the stored accounts. It shares the app's modules, so this
+      // costs a small extra chunk, not a second copy. See src/headless.ts.
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        headless: path.resolve(__dirname, 'headless.html'),
+      },
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
Some OEM WebViews skip Capacitor's own safe-area handling, leaving content
under the status bar. SafeAreaInsets applies the insets directly, reapplied
on page commit so it survives navigation.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016HWjp1V6Yvr4PNVWsayep1