### PR TITLE
feat(caldav): CREATED/LAST-MODIFIED, plus three fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to Calino will be documented in this file.
 
 ### Fixed
 
+- **Duplicated events are saved to the server.** Duplicating an event — from the context menu, ctrl+clicking it, or ctrl+dragging it to a new slot — only ever created the copy locally. It looked right until the next sync, which removed it again: the server had never been told about it. The copy is now pushed like any other new event, and a failed push is queued for retry rather than lost.
+
 - **Journal entries write their timestamps in UTC.** `CREATED` and `LAST-MODIFIED` on a journal entry were emitted as floating local times, which RFC 5545 §3.8.7 doesn't allow — a server or client in another zone read them hours off.
 
 ## [0.27.3] - 2026-08-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to Calino will be documented in this file.
 
 - **Duplicated events are saved to the server.** Duplicating an event — from the context menu, ctrl+clicking it, or ctrl+dragging it to a new slot — only ever created the copy locally. It looked right until the next sync, which removed it again: the server had never been told about it. The copy is now pushed like any other new event, and a failed push is queued for retry rather than lost.
 
+- **No stray horizontal scrollbar in the sidebar.** On the desktop layout the sidebar sometimes showed a scrollbar along its bottom edge even though nothing extended sideways.
+
 - **Journal entries write their timestamps in UTC.** `CREATED` and `LAST-MODIFIED` on a journal entry were emitted as floating local times, which RFC 5545 §3.8.7 doesn't allow — a server or client in another zone read them hours off.
 
 ## [0.27.3] - 2026-08-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Calino will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Tasks and events now carry a creation date** ([#112](https://github.com/Ivan-Malinovski/calino/issues/112), reported by [@riblet](https://github.com/riblet)). Everything Calino writes to a server now includes `CREATED` and `LAST-MODIFIED` alongside the `DTSTAMP` it already had. RFC 5545 doesn't require `CREATED`, but plenty of software assumes it is there — the reported case is MMM-CalDAV-Tasks, which appends `COMPLETED` *after* `END:VTODO` when it can't find one, corrupting the task.
+
+  `CREATED` is now also read back when Calino pulls a task or event in. That matters more than it sounds: Calino rebuilds each component from scratch on every save, so before this change a creation date written by any other client was silently dropped the first time you edited that task here. Records that predate this — and ones whose server copy never had a `CREATED` — get stamped with the current time on their next save, and hold that value from then on. `LAST-MODIFIED` tracks each write and matches the `DTSTAMP` on it exactly.
+
+### Fixed
+
+- **Journal entries write their timestamps in UTC.** `CREATED` and `LAST-MODIFIED` on a journal entry were emitted as floating local times, which RFC 5545 §3.8.7 doesn't allow — a server or client in another zone read them hours off.
+
 ## [0.27.3] - 2026-08-07
 
 ### Added

--- a/src/features/caldav/adapter/__tests__/iCalendarAdapter.test.ts
+++ b/src/features/caldav/adapter/__tests__/iCalendarAdapter.test.ts
@@ -864,6 +864,161 @@ END:VCALENDAR`
     })
   })
 
+  // #112 — CREATED/LAST-MODIFIED. Components are rebuilt from scratch on every
+  // save, so CREATED only survives because the parsers read it back.
+  describe('CREATED and LAST-MODIFIED', () => {
+    const baseTask: CalendarEvent = {
+      id: 'task-audit',
+      title: 'Audited task',
+      start: '2024-03-20T00:00:00',
+      end: '2024-03-20T23:59:59',
+      isAllDay: true,
+      calendarId: 'cal-1',
+      type: 'task',
+      dueDate: '2024-03-20T00:00:00',
+    }
+
+    const baseEvent: CalendarEvent = {
+      id: 'event-audit',
+      title: 'Audited event',
+      start: '2024-03-20T10:00:00.000Z',
+      end: '2024-03-20T11:00:00.000Z',
+      isAllDay: false,
+      calendarId: 'cal-1',
+    }
+
+    it('emits both stamps in UTC form on a VTODO', () => {
+      const iCal = taskToICAL(baseTask)
+
+      expect(iCal).toMatch(/CREATED:\d{8}T\d{6}Z/)
+      expect(iCal).toMatch(/LAST-MODIFIED:\d{8}T\d{6}Z/)
+    })
+
+    it('emits both stamps in UTC form on a VEVENT', () => {
+      const iCal = eventToICAL(baseEvent)
+
+      expect(iCal).toMatch(/CREATED:\d{8}T\d{6}Z/)
+      expect(iCal).toMatch(/LAST-MODIFIED:\d{8}T\d{6}Z/)
+    })
+
+    it('serializes a stored creation time verbatim', () => {
+      const iCal = taskToICAL({ ...baseTask, created: '2020-01-02T03:04:05.000Z' })
+
+      expect(iCal).toContain('CREATED:20200102T030405Z')
+    })
+
+    it('stamps a task with no stored creation time with the current time', () => {
+      const before = Date.now()
+      const iCal = taskToICAL(baseTask)
+      const stamped = iCal.match(
+        /CREATED:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/
+      ) as RegExpMatchArray
+
+      expect(stamped).not.toBeNull()
+      const [, y, mo, d, h, mi, s] = stamped.map(Number)
+      const parsed = Date.UTC(y, mo - 1, d, h, mi, s)
+      // Truncated to whole seconds on the wire, so allow the second boundary.
+      expect(parsed).toBeGreaterThanOrEqual(before - 1000)
+      expect(parsed).toBeLessThanOrEqual(Date.now() + 1000)
+    })
+
+    it('falls back to now when the stored creation time is unparseable', () => {
+      const iCal = taskToICAL({ ...baseTask, created: 'not-a-date' })
+
+      expect(iCal).toMatch(/CREATED:\d{8}T\d{6}Z/)
+    })
+
+    it('reads both stamps off a VTODO', () => {
+      const [parsed] = parseICALTask(
+        `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:task-with-stamps
+SUMMARY:Stamped
+CREATED:20200102T030405Z
+LAST-MODIFIED:20210203T040506Z
+END:VTODO
+END:VCALENDAR`,
+        'cal-1'
+      )
+
+      expect(parsed?.created).toBe('2020-01-02T03:04:05.000Z')
+      expect(parsed?.lastModified).toBe('2021-02-03T04:05:06.000Z')
+    })
+
+    it('leaves both stamps undefined when the VTODO omits them', () => {
+      const [parsed] = parseICALTask(
+        `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:task-no-stamps
+SUMMARY:Unstamped
+END:VTODO
+END:VCALENDAR`,
+        'cal-1'
+      )
+
+      expect(parsed?.created).toBeUndefined()
+      expect(parsed?.lastModified).toBeUndefined()
+    })
+
+    it('reads both stamps off a VEVENT', () => {
+      const [parsed] = parseICALEvent(
+        `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-with-stamps
+SUMMARY:Stamped
+DTSTART:20240320T100000Z
+DTEND:20240320T110000Z
+CREATED:20200102T030405Z
+LAST-MODIFIED:20210203T040506Z
+END:VEVENT
+END:VCALENDAR`,
+        'cal-1'
+      )
+
+      expect(parsed?.created).toBe('2020-01-02T03:04:05.000Z')
+      expect(parsed?.lastModified).toBe('2021-02-03T04:05:06.000Z')
+    })
+
+    it('preserves a task CREATED across a parse/serialize round-trip', () => {
+      const original = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:task-round-trip
+SUMMARY:Round trip
+CREATED:20200102T030405Z
+LAST-MODIFIED:20210203T040506Z
+END:VTODO
+END:VCALENDAR`
+
+      const reserialized = taskToICAL(parseICALTask(original, 'cal-1')[0])
+
+      expect(reserialized).toContain('CREATED:20200102T030405Z')
+      // LAST-MODIFIED tracks the write, so it must have moved on.
+      expect(reserialized).not.toContain('LAST-MODIFIED:20210203T040506Z')
+      expect(parseICALTask(reserialized, 'cal-1')[0].created).toBe('2020-01-02T03:04:05.000Z')
+    })
+
+    it('preserves an event CREATED across a parse/serialize round-trip', () => {
+      const original = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-round-trip
+SUMMARY:Round trip
+DTSTART:20240320T100000Z
+DTEND:20240320T110000Z
+CREATED:20200102T030405Z
+END:VEVENT
+END:VCALENDAR`
+
+      const reserialized = eventToICAL(parseICALEvent(original, 'cal-1')[0])
+
+      expect(reserialized).toContain('CREATED:20200102T030405Z')
+    })
+  })
+
   describe('parseICALData', () => {
     it('parses both events and tasks from combined iCal data', () => {
       const iCalData = `BEGIN:VCALENDAR

--- a/src/features/caldav/adapter/icalTypeMapping.ts
+++ b/src/features/caldav/adapter/icalTypeMapping.ts
@@ -407,6 +407,48 @@ function icalTimeToISO(icalTime: ICAL.Time, prop?: ICAL.Property): IcalTimeToISO
   return { iso: jsDate.toISOString() }
 }
 
+/**
+ * Read one UTC audit stamp (CREATED / LAST-MODIFIED) off a component.
+ * Returns undefined when the property is absent or unparseable — callers
+ * must not invent a value, because a fabricated CREATED would overwrite the
+ * real one the store already holds.
+ */
+function readAuditStamp(
+  comp: ICAL.Component,
+  name: 'created' | 'last-modified'
+): string | undefined {
+  const prop = comp.getFirstProperty(name)
+  if (!prop) return undefined
+  try {
+    const value = prop.getFirstValue()
+    if (value instanceof ICAL.Time) return icalTimeToISO(value).iso
+  } catch {
+    /* malformed stamp — treat as absent */
+  }
+  return undefined
+}
+
+/**
+ * Write CREATED and LAST-MODIFIED (RFC 5545 §3.8.7.1 / §3.8.7.3). Both must be
+ * UTC, hence the `true` on fromJSDate.
+ *
+ * We rebuild every component from scratch on save, so CREATED only survives
+ * because the parsers read it back into `event.created`. When it is missing —
+ * a record written before this existed, or one whose stored value is junk — we
+ * stamp `now` rather than omitting the property: the whole point of issue #112
+ * is that clients in the wild break when CREATED is absent. That stamp is then
+ * parsed back on the next sync, so it moves once and then holds.
+ *
+ * `now` is passed in so LAST-MODIFIED cannot disagree with the caller's
+ * DTSTAMP by a millisecond.
+ */
+function writeAuditStamps(comp: ICAL.Component, event: CalendarEvent, now: Date): void {
+  const stored = event.created ? new Date(event.created) : undefined
+  const created = stored && !isNaN(stored.getTime()) ? stored : now
+  comp.updatePropertyWithValue('created', ICAL.Time.fromJSDate(created, true))
+  comp.updatePropertyWithValue('last-modified', ICAL.Time.fromJSDate(now, true))
+}
+
 export function icalEventToCalendarEvent(
   vevent: ICAL.Component,
   calendarId: string
@@ -615,6 +657,8 @@ export function icalEventToCalendarEvent(
     recurrenceMasterId: recurrenceId ? uid : undefined,
     eventStatus,
     attachments: attachments.length > 0 ? attachments : undefined,
+    created: readAuditStamp(vevent, 'created'),
+    lastModified: readAuditStamp(vevent, 'last-modified'),
   }
 }
 
@@ -684,9 +728,12 @@ function createAllDayDate(year: number, month: number, day: number): ICAL.Time {
 export function calendarEventToIcalComponent(event: CalendarEvent): ICAL.Component {
   const vevent = new ICAL.Component('vevent')
 
+  const now = new Date()
+
   vevent.updatePropertyWithValue('uid', event.uid || event.recurrenceMasterId || event.id)
-  vevent.updatePropertyWithValue('dtstamp', ICAL.Time.fromJSDate(new Date(), true))
+  vevent.updatePropertyWithValue('dtstamp', ICAL.Time.fromJSDate(now, true))
   vevent.updatePropertyWithValue('sequence', event.sequence ?? 0)
+  writeAuditStamps(vevent, event, now)
   if (event.eventStatus) {
     vevent.updatePropertyWithValue('status', event.eventStatus)
   }
@@ -1139,6 +1186,8 @@ export function icalVtodoToCalendarEvent(vtodo: ICAL.Component, calendarId: stri
     excludedDates: excludedDates.length > 0 ? excludedDates : undefined,
     recurrenceId,
     recurrenceMasterId: recurrenceId ? uid : undefined,
+    created: readAuditStamp(vtodo, 'created'),
+    lastModified: readAuditStamp(vtodo, 'last-modified'),
   }
 }
 
@@ -1148,9 +1197,12 @@ export function calendarEventToIcalVtodo(task: CalendarEvent): ICAL.Component {
   // R2.7 — A detached override carries the master's UID, so prefer the stored
   // UID over the local id (which for an override is `${uid}-${recurrenceId}`).
   // Falling back to task.id keeps tasks written before this change stable.
+  const now = new Date()
+
   vtodo.updatePropertyWithValue('uid', task.uid || task.recurrenceMasterId || task.id)
-  vtodo.updatePropertyWithValue('dtstamp', ICAL.Time.fromJSDate(new Date(), true))
+  vtodo.updatePropertyWithValue('dtstamp', ICAL.Time.fromJSDate(now, true))
   vtodo.updatePropertyWithValue('sequence', task.sequence ?? 0)
+  writeAuditStamps(vtodo, task, now)
   vtodo.updatePropertyWithValue('summary', task.title)
 
   // R2.7 — DTSTART must be present to anchor an RRULE, and DUE's value type
@@ -1407,9 +1459,12 @@ export function icalVjournalToCalendarEvent(
 export function calendarEventToIcalVjournal(entry: CalendarEvent): ICAL.Component {
   const vjournal = new ICAL.Component('vjournal')
 
+  const now = new Date()
+
   vjournal.updatePropertyWithValue('uid', entry.id)
-  vjournal.updatePropertyWithValue('dtstamp', ICAL.Time.fromJSDate(new Date(), true))
+  vjournal.updatePropertyWithValue('dtstamp', ICAL.Time.fromJSDate(now, true))
   vjournal.updatePropertyWithValue('sequence', entry.sequence ?? 0)
+  writeAuditStamps(vjournal, entry, now)
 
   // DTSTART — date only for journal entries
   const dateParts = entry.start.split('-')
@@ -1430,25 +1485,6 @@ export function calendarEventToIcalVjournal(entry: CalendarEvent): ICAL.Componen
 
   if (entry.categories && entry.categories.length > 0) {
     vjournal.updatePropertyWithValue('categories', entry.categories.join(','))
-  }
-
-  if (entry.created) {
-    try {
-      vjournal.updatePropertyWithValue('created', ICAL.Time.fromJSDate(new Date(entry.created)))
-    } catch {
-      /* skip */
-    }
-  }
-
-  if (entry.lastModified) {
-    try {
-      vjournal.updatePropertyWithValue(
-        'last-modified',
-        ICAL.Time.fromJSDate(new Date(entry.lastModified))
-      )
-    } catch {
-      /* skip */
-    }
   }
 
   if (entry.url) {

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -67,6 +67,7 @@ import { getJournalDates, getTasksForDay } from '@/store/calendarStore'
 import { hasDueTime } from '@/lib/events'
 import { consumesVerticalScroll } from '@/lib/scrollChaining'
 import styles from './CalendarGrid.module.css'
+import { duplicateEventWithSync } from '@/lib/duplicateWithSync'
 
 // Shared by the button and span forms of the journal indicator (see the
 // compact-mobile branch in DroppableDay).
@@ -123,7 +124,6 @@ export function CalendarGrid(): JSX.Element {
   const rangeExpansionVersion = useCalendarStore((state) => state.rangeExpansionVersion)
   const openModal = useCalendarStore((state) => state.openModal)
   const storeUpdateEvent = useCalendarStore((state) => state.updateEvent)
-  const duplicateEvent = useCalendarStore((state) => state.duplicateEvent)
   const setCurrentDate = useCalendarStore((state) => state.setCurrentDate)
   const setCurrentView = useCalendarStore((state) => state.setCurrentView)
   const isOverlayOpen = useCalendarStore((state) => state.isOverlayOpen)
@@ -142,7 +142,7 @@ export function CalendarGrid(): JSX.Element {
   const monthAgendaSplitRatioSetting = useSettingsStore((state) => state.monthAgendaSplitRatio)
   const updateSettings = useSettingsStore((state) => state.updateSettings)
 
-  const { updateEvent: caldavUpdateEvent } = useCalDAV()
+  const { updateEvent: caldavUpdateEvent, createEvent: createCalDAVEvent } = useCalDAV()
 
   const { bind } = useGestures({
     onSwipe: (direction) => {
@@ -456,9 +456,12 @@ export function CalendarGrid(): JSX.Element {
     }
 
     if (shouldDuplicate) {
-      const newId = duplicateEvent(originalEvent.id, false)
-      if (!newId) return
-      storeUpdateEvent(newId, updates)
+      duplicateEventWithSync({
+        eventId: originalEvent.id,
+        addCopySuffix: false,
+        updates: updates,
+        createCalDAVEvent,
+      })
       return
     }
 

--- a/src/features/calendar/components/CalendarHeader.module.css
+++ b/src/features/calendar/components/CalendarHeader.module.css
@@ -49,6 +49,7 @@
 }
 
 .brandDiamond {
+  flex: none;
   width: 11px;
   height: 11px;
   border-radius: 3px;
@@ -63,6 +64,13 @@
   font-size: 27px;
   letter-spacing: -0.01em;
   color: var(--ink);
+  /* "Calino" has no descenders, so the descender room the line box reserves is
+     dead space that pushes the glyphs above the diamond. Collapse to the em box
+     (Newsreader is ascent .735 / descent .265, so line-height 1 adds no leading)
+     and shift down by the residual: the letters span cap-top .065em to baseline
+     .735em, centring at .40em — .10em shy of the box centre. */
+  line-height: 1;
+  transform: translateY(0.1em);
 }
 
 /* ---- Navigator (Grouped Segmented Control) ---- */

--- a/src/features/calendar/components/DayView.tsx
+++ b/src/features/calendar/components/DayView.tsx
@@ -55,6 +55,7 @@ import {
 } from '../lib/dragSnap'
 import type { CalendarEvent } from '@/types'
 import styles from './DayView.module.css'
+import { duplicateEventWithSync } from '@/lib/duplicateWithSync'
 
 const DRAG_ACTIVATION_CONSTRAINT = 8
 const TOUCH_DRAG_ACTIVATION_DELAY = 200
@@ -105,7 +106,6 @@ export function DayView({
   const getEventsForDateRange = useCalendarStore((state) => state.getEventsForDateRange)
   const openModal = useCalendarStore((state) => state.openModal)
   const storeUpdateEvent = useCalendarStore((state) => state.updateEvent)
-  const duplicateEvent = useCalendarStore((state) => state.duplicateEvent)
   const setCurrentDate = useCalendarStore((state) => state.setCurrentDate)
   const timeFormat = useSettingsStore((state) => state.timeFormat)
 
@@ -128,7 +128,7 @@ export function DayView({
   const openMenu = useContextMenuStore((state) => state.openMenu)
   const closeMenu = useContextMenuStore((state) => state.closeMenu)
 
-  const { updateEvent: caldavUpdateEvent } = useCalDAV()
+  const { updateEvent: caldavUpdateEvent, createEvent: createCalDAVEvent } = useCalDAV()
 
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; hour?: number } | null>(
     null
@@ -484,9 +484,12 @@ export function DayView({
         isAllDay: true,
       }
       if (shouldDuplicate) {
-        const newId = duplicateEvent(originalEvent.id, false)
-        if (!newId) return
-        storeUpdateEvent(newId, allDayUpdates)
+        duplicateEventWithSync({
+          eventId: originalEvent.id,
+          addCopySuffix: false,
+          updates: allDayUpdates,
+          createCalDAVEvent,
+        })
         return
       }
       storeUpdateEvent(String(active.id), allDayUpdates)
@@ -543,9 +546,12 @@ export function DayView({
     }
 
     if (shouldDuplicate) {
-      const newId = duplicateEvent(originalEvent.id, false)
-      if (!newId) return
-      storeUpdateEvent(newId, updates)
+      duplicateEventWithSync({
+        eventId: originalEvent.id,
+        addCopySuffix: false,
+        updates: updates,
+        createCalDAVEvent,
+      })
       return
     }
 

--- a/src/features/calendar/components/EventCard.tsx
+++ b/src/features/calendar/components/EventCard.tsx
@@ -33,6 +33,7 @@ import { EventBackground } from '@/components/common/EventBackground'
 import { matchEventBackground } from '@/lib/eventBackground'
 import { MINUTE_SNAP_INTERVAL } from '../lib/dragSnap'
 import styles from './EventCard.module.css'
+import { duplicateEventWithSync } from '@/lib/duplicateWithSync'
 
 interface EventCardProps {
   event: CalendarEvent
@@ -84,7 +85,6 @@ export const EventCard = React.memo(function EventCard({
   const completeTaskOccurrence = useCalendarStore((state) => state.completeTaskOccurrence)
   const deleteEvent = useCalendarStore((state) => state.deleteEvent)
   const addEvent = useCalendarStore((state) => state.addEvent)
-  const duplicateEvent = useCalendarStore((state) => state.duplicateEvent)
   const timeFormat = useSettingsStore((state) => state.timeFormat)
   const defaultDuration = useSettingsStore((state) => state.defaultDuration)
   const {
@@ -283,7 +283,7 @@ export const EventCard = React.memo(function EventCard({
 
     // Ctrl/Cmd+click is a shortcut for the context menu's "Duplicate" action.
     if ((e.ctrlKey || e.metaKey) && !isReadOnlyCalendar) {
-      duplicateEvent(event.id)
+      duplicateEventWithSync({ eventId: event.id, createCalDAVEvent })
       return
     }
 
@@ -780,7 +780,8 @@ export const EventCard = React.memo(function EventCard({
                     },
                     {
                       label: 'Duplicate',
-                      onClick: () => duplicateEvent(event.id),
+                      onClick: () =>
+                        duplicateEventWithSync({ eventId: event.id, createCalDAVEvent }),
                       icon: <DuplicateIcon />,
                     },
                     {

--- a/src/features/calendar/components/EventPreviewPopup.tsx
+++ b/src/features/calendar/components/EventPreviewPopup.tsx
@@ -398,6 +398,10 @@ export function EventPreviewPopup({
         reminders: masterEvent.reminders,
         transparency: masterEvent.transparency,
         sequence: 0,
+        // #112 — a split series is a new VTODO/VEVENT, so it must not inherit
+        // the master's CREATED. `addEvent` stamps the real time below.
+        created: undefined,
+        lastModified: undefined,
       }
       store.addEvent(newSeriesEvent)
       try {

--- a/src/features/calendar/components/Sidebar.module.css
+++ b/src/features/calendar/components/Sidebar.module.css
@@ -46,6 +46,12 @@
      a short viewport (a long task list, many calendars) were simply
      unreachable. */
   overflow-y: auto;
+  /* `overflow-y: auto` alone computes the x axis to `auto` as well, so any
+     child a fraction of a pixel too wide — the mini calendar's grid once the
+     vertical scrollbar eats into the width, a card's shadow — put a horizontal
+     scrollbar under the whole sidebar. Nothing here is meant to scroll
+     sideways. */
+  overflow-x: hidden;
   overscroll-behavior: contain;
 }
 

--- a/src/features/calendar/components/Sidebar.module.css
+++ b/src/features/calendar/components/Sidebar.module.css
@@ -150,11 +150,18 @@
      scroll container, so flush against the left edge the ring was clipped and
      the mark looked shaved. Inset by the spread; the glow's outer edge then
      lines up with the cards below, which is the correct optical alignment
-     anyway. */
-  padding: 12px 0 4px 4px;
+     anyway. The diamond is rotated, so the inset has to clear its *diagonal*
+     half-width (≈13.4px from centre) minus the 5.5px the layout box already
+     reserves — 4px was measured off the unrotated square and still clipped.
+
+     The top inset matches the desktop wordmark's: the header pads 18px and
+     centres the 27px mark in its 38px navigator row, putting its box 23.5px
+     down. .sidebar contributes 1px, so this covers the remaining 22.5px. */
+  padding: 22.5px 0 4px 8px;
 }
 
 .sidebarBrandDiamond {
+  flex: none;
   width: 11px;
   height: 11px;
   border-radius: 3px;
@@ -169,6 +176,13 @@
   font-size: 27px;
   letter-spacing: -0.01em;
   color: var(--ink);
+  /* "Calino" has no descenders, so the descender room the line box reserves is
+     dead space that pushes the glyphs above the diamond. Collapse to the em box
+     (Newsreader is ascent .735 / descent .265, so line-height 1 adds no leading)
+     and shift down by the residual: the letters span cap-top .065em to baseline
+     .735em, centring at .40em — .10em shy of the box centre. */
+  line-height: 1;
+  transform: translateY(0.1em);
 }
 
 .expandButton,

--- a/src/features/calendar/components/WeekView.tsx
+++ b/src/features/calendar/components/WeekView.tsx
@@ -58,6 +58,7 @@ import {
 } from '../lib/dragSnap'
 import { SWIPE_SCROLLER_ATTR } from '../swipePaging'
 import styles from './WeekView.module.css'
+import { duplicateEventWithSync } from '@/lib/duplicateWithSync'
 
 const BASE_HOUR_HEIGHT = 60
 /** Narrowest the mobile day columns compress to, as a fraction of their normal
@@ -152,7 +153,6 @@ export function WeekView({ dayCount = 7 }: { dayCount?: number } = {}): JSX.Elem
   const rangeExpansionVersion = useCalendarStore((state) => state.rangeExpansionVersion)
   const openModal = useCalendarStore((state) => state.openModal)
   const storeUpdateEvent = useCalendarStore((state) => state.updateEvent)
-  const duplicateEvent = useCalendarStore((state) => state.duplicateEvent)
   const setCurrentDate = useCalendarStore((state) => state.setCurrentDate)
   const firstDayOfWeek = useSettingsStore((state) => state.firstDayOfWeek)
   const timeFormat = useSettingsStore((state) => state.timeFormat)
@@ -160,7 +160,7 @@ export function WeekView({ dayCount = 7 }: { dayCount?: number } = {}): JSX.Elem
   const openMenu = useContextMenuStore((state) => state.openMenu)
   const closeMenu = useContextMenuStore((state) => state.closeMenu)
 
-  const { updateEvent: caldavUpdateEvent } = useCalDAV()
+  const { updateEvent: caldavUpdateEvent, createEvent: createCalDAVEvent } = useCalDAV()
 
   const [activeEvent, setActiveEvent] = useState<CalendarEvent | null>(null)
   const [dropPreview, setDropPreview] = useState<DropPreview | null>(null)
@@ -665,9 +665,12 @@ export function WeekView({ dayCount = 7 }: { dayCount?: number } = {}): JSX.Elem
         isAllDay: true,
       }
       if (shouldDuplicate) {
-        const newId = duplicateEvent(originalEvent.id, false)
-        if (!newId) return
-        storeUpdateEvent(newId, allDayUpdates)
+        duplicateEventWithSync({
+          eventId: originalEvent.id,
+          addCopySuffix: false,
+          updates: allDayUpdates,
+          createCalDAVEvent,
+        })
         return
       }
       storeUpdateEvent(String(active.id), allDayUpdates)
@@ -723,9 +726,12 @@ export function WeekView({ dayCount = 7 }: { dayCount?: number } = {}): JSX.Elem
     }
 
     if (shouldDuplicate) {
-      const newId = duplicateEvent(originalEvent.id, false)
-      if (!newId) return
-      storeUpdateEvent(newId, updates)
+      duplicateEventWithSync({
+        eventId: originalEvent.id,
+        addCopySuffix: false,
+        updates: updates,
+        createCalDAVEvent,
+      })
       return
     }
 

--- a/src/features/webcal/hooks/useWebcalSubscriptions.ts
+++ b/src/features/webcal/hooks/useWebcalSubscriptions.ts
@@ -129,7 +129,19 @@ export function useWebcalSubscriptions(): UseWebcalSubscriptionsReturn {
           const existing = existingById.get(id)
           if (!existing) {
             storeAddEvent(event)
-          } else if (JSON.stringify(existing) !== JSON.stringify(event)) {
+          } else if (
+            // #112 — a feed without CREATED parses to `created: undefined`,
+            // while the stored copy carries the stamp we gave it on first
+            // sight. Comparing those directly reports every event as changed
+            // on every refresh, so hold the local stamps steady here; the
+            // store keeps them anyway.
+            JSON.stringify(existing) !==
+            JSON.stringify({
+              ...event,
+              created: event.created ?? existing.created,
+              lastModified: event.lastModified ?? existing.lastModified,
+            })
+          ) {
             storeUpdateEvent(id, event)
           }
         }

--- a/src/lib/__tests__/duplicateWithSync.test.ts
+++ b/src/lib/__tests__/duplicateWithSync.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { duplicateEventWithSync } from '../duplicateWithSync'
+import { useCalendarStore } from '@/store/calendarStore'
+import type { CalendarEvent } from '@/types'
+
+const baseEvent: CalendarEvent = {
+  id: 'original-1',
+  title: 'Standup',
+  start: '2026-08-11T09:00:00.000Z',
+  end: '2026-08-11T09:30:00.000Z',
+  calendarId: 'work',
+  type: 'event',
+  isAllDay: false,
+}
+
+describe('duplicateEventWithSync', () => {
+  beforeEach(() => {
+    useCalendarStore.setState({ events: [baseEvent] })
+  })
+
+  it('pushes the copy to CalDAV', () => {
+    const createCalDAVEvent = vi.fn().mockResolvedValue(undefined)
+    const newId = duplicateEventWithSync({ eventId: 'original-1', createCalDAVEvent })
+
+    expect(newId).toBeTruthy()
+    expect(createCalDAVEvent).toHaveBeenCalledTimes(1)
+    const [calendarId, pushed] = createCalDAVEvent.mock.calls[0]
+    expect(calendarId).toBe('work')
+    expect(pushed.id).toBe(newId)
+    expect(pushed.title).toBe('Standup (copy)')
+  })
+
+  it('pushes the copy with drag updates already applied', () => {
+    const createCalDAVEvent = vi.fn().mockResolvedValue(undefined)
+    duplicateEventWithSync({
+      eventId: 'original-1',
+      addCopySuffix: false,
+      updates: { start: '2026-08-12T14:00:00.000Z', end: '2026-08-12T14:30:00.000Z' },
+      createCalDAVEvent,
+    })
+
+    const [, pushed] = createCalDAVEvent.mock.calls[0]
+    expect(pushed.title).toBe('Standup')
+    expect(pushed.start).toBe('2026-08-12T14:00:00.000Z')
+    expect(pushed.end).toBe('2026-08-12T14:30:00.000Z')
+  })
+
+  it('does not push copies of local-only events', () => {
+    useCalendarStore.setState({ events: [{ ...baseEvent, calendarId: 'default' }] })
+    const createCalDAVEvent = vi.fn().mockResolvedValue(undefined)
+
+    const newId = duplicateEventWithSync({ eventId: 'original-1', createCalDAVEvent })
+
+    expect(newId).toBeTruthy()
+    expect(createCalDAVEvent).not.toHaveBeenCalled()
+  })
+
+  it('returns null and pushes nothing when the source is gone', () => {
+    const createCalDAVEvent = vi.fn().mockResolvedValue(undefined)
+    expect(duplicateEventWithSync({ eventId: 'missing', createCalDAVEvent })).toBeNull()
+    expect(createCalDAVEvent).not.toHaveBeenCalled()
+  })
+
+  it('survives a failed push without throwing', async () => {
+    const createCalDAVEvent = vi.fn().mockRejectedValue(new Error('offline'))
+    expect(() => duplicateEventWithSync({ eventId: 'original-1', createCalDAVEvent })).not.toThrow()
+    await Promise.resolve()
+  })
+})

--- a/src/lib/duplicateWithSync.ts
+++ b/src/lib/duplicateWithSync.ts
@@ -1,0 +1,48 @@
+import type { CalendarEvent } from '@/types'
+import { useCalendarStore } from '@/store/calendarStore'
+import { showToast } from './toast'
+
+interface DuplicateEventWithSyncOptions {
+  /** Id of the event to copy. */
+  eventId: string
+  /** Appends " (copy)" to the title — off for ctrl+drag, which places a copy. */
+  addCopySuffix?: boolean
+  /** Applied to the copy before it is pushed (the drop position, typically). */
+  updates?: Partial<CalendarEvent>
+  createCalDAVEvent?: (calendarId: string, event: CalendarEvent) => Promise<void>
+}
+
+/**
+ * Duplicate an event and push the copy to CalDAV.
+ *
+ * `duplicateEvent` only writes to the local store. Every duplicate path used
+ * to stop there, so the copy looked fine until the next sync pass, which
+ * removed it again — the server had never heard of it. Any UI that duplicates
+ * must go through here.
+ */
+export function duplicateEventWithSync({
+  eventId,
+  addCopySuffix = true,
+  updates,
+  createCalDAVEvent,
+}: DuplicateEventWithSyncOptions): string | null {
+  const store = useCalendarStore.getState()
+  const newId = store.duplicateEvent(eventId, addCopySuffix)
+  if (!newId) return null
+
+  if (updates) {
+    store.updateEvent(newId, updates)
+  }
+
+  // Read back rather than reusing the pre-update copy: `addEvent`/`updateEvent`
+  // apply auto-categories and the #112 creation stamp, and the server should
+  // get what the store actually holds.
+  const copy = useCalendarStore.getState().events.find((e) => e.id === newId)
+  if (copy && copy.calendarId !== 'default') {
+    createCalDAVEvent?.(copy.calendarId, copy).catch(() => {
+      showToast('Failed to sync the duplicated event. It will be retried.')
+    })
+  }
+
+  return newId
+}

--- a/src/store/__tests__/calendarStore.test.ts
+++ b/src/store/__tests__/calendarStore.test.ts
@@ -1925,4 +1925,67 @@ describe('calendarStore', () => {
       expect(apr3[0].title).toBe('Special Standup')
     })
   })
+
+  // #112 — `created` becomes the CREATED property on the wire, so it has to
+  // be stamped once and then left alone.
+  describe('creation timestamps', () => {
+    const base = {
+      calendarId: 'default',
+      title: 'Stamped',
+      start: '2024-03-15T10:00:00.000Z',
+      end: '2024-03-15T11:00:00.000Z',
+      isAllDay: false,
+    }
+
+    it('stamps created on an event that has none', () => {
+      const before = Date.now()
+      useCalendarStore.getState().addEvent({ ...base, id: 'stamp-1' })
+
+      const stored = useCalendarStore.getState().events.find((e) => e.id === 'stamp-1')!
+      expect(stored.created).toBeDefined()
+      const stamped = new Date(stored.created as string).getTime()
+      expect(stamped).toBeGreaterThanOrEqual(before)
+      expect(stamped).toBeLessThanOrEqual(Date.now())
+    })
+
+    it('keeps a created value supplied by the caller', () => {
+      useCalendarStore
+        .getState()
+        .addEvent({ ...base, id: 'stamp-2', created: '2020-01-02T03:04:05.000Z' })
+
+      expect(useCalendarStore.getState().events.find((e) => e.id === 'stamp-2')!.created).toBe(
+        '2020-01-02T03:04:05.000Z'
+      )
+    })
+
+    it('does not let an update clear created', () => {
+      const store = useCalendarStore.getState()
+      store.addEvent({ ...base, id: 'stamp-3', created: '2020-01-02T03:04:05.000Z' })
+
+      // This is the shape sync uses: a whole parsed event, whose `created` is
+      // an explicit undefined when the server copy carried no CREATED.
+      store.updateEvent('stamp-3', {
+        ...base,
+        id: 'stamp-3',
+        title: 'Stamped (from server)',
+        created: undefined,
+      })
+
+      const stored = useCalendarStore.getState().events.find((e) => e.id === 'stamp-3')!
+      expect(stored.created).toBe('2020-01-02T03:04:05.000Z')
+      expect(stored.title).toBe('Stamped (from server)')
+    })
+
+    it('gives a duplicate its own created rather than the original’s', () => {
+      const store = useCalendarStore.getState()
+      store.addEvent({ ...base, id: 'stamp-4', created: '2020-01-02T03:04:05.000Z' })
+
+      const newId = store.duplicateEvent('stamp-4')
+      const duplicate = useCalendarStore.getState().events.find((e) => e.id === newId!)!
+
+      expect(duplicate.created).toBeDefined()
+      expect(duplicate.created).not.toBe('2020-01-02T03:04:05.000Z')
+      expect(duplicate.lastModified).toBeUndefined()
+    })
+  })
 })

--- a/src/store/calendarStore.ts
+++ b/src/store/calendarStore.ts
@@ -512,6 +512,11 @@ export const useCalendarStore = create<CalendarStore>()(
         const finalEvent = {
           ...event,
           categories: [...new Set([...existingCategories, ...autoCategoryNames])],
+          // #112 — CREATED is written from this. Locally created records get
+          // their real creation time here rather than waiting for a sync
+          // round-trip; synced ones arrive with `created` already parsed off
+          // the server's CREATED, so `??` leaves them alone.
+          created: event.created ?? new Date().toISOString(),
         }
         set((state) => {
           // Same id can arrive twice in one sync pass (e.g. the same UID
@@ -530,6 +535,12 @@ export const useCalendarStore = create<CalendarStore>()(
 
       updateEvent: (id: string, updates: Partial<CalendarEvent>): void => {
         const safeUpdates = { ...updates }
+        // #112 — `created` is write-once. Sync hands whole parsed events to
+        // this action, and a server copy carrying no CREATED parses to
+        // `created: undefined` — an explicit key, so the spread below would
+        // wipe the stamp `addEvent` made. Dropping the key keeps the first
+        // creation time we ever knew about.
+        if (safeUpdates.created === undefined) delete safeUpdates.created
         if (safeUpdates.start !== undefined && safeUpdates.end !== undefined) {
           if (safeUpdates.start > safeUpdates.end && !safeUpdates.isAllDay) {
             const reason = `start (${safeUpdates.start}) > end (${safeUpdates.end})`
@@ -828,6 +839,12 @@ export const useCalendarStore = create<CalendarStore>()(
           etag: undefined,
           resourceHref: undefined,
           sequence: undefined,
+          // #112 — a copy is a new record. Inheriting the original's CREATED
+          // would tell the server this task was created years ago. This path
+          // writes straight to `events` rather than going through `addEvent`,
+          // so it stamps its own creation time.
+          created: new Date().toISOString(),
+          lastModified: undefined,
         }
 
         set((state) => ({


### PR DESCRIPTION
Batches the four commits that were sitting unpushed on this branch, so they can go out with the 0.27.4 release.

- **feat(caldav): add CREATED and LAST-MODIFIED to tasks and events** (#112)
- **fix(calendar): push duplicated events to the server**
- **fix(sidebar): stop the stray horizontal scrollbar**
- **fix(brand): centre the Calino wordmark against its diamond**

🤖 Generated with [Claude Code](https://claude.com/claude-code)