### PR TITLE
fix(caldav): keep events when a parallel component query fails

### DIFF
--- a/e2e/calendar-sync.spec.ts
+++ b/e2e/calendar-sync.spec.ts
@@ -142,6 +142,45 @@ END:VCALENDAR`,
     await expect(page.locator('#priority-select')).toHaveValue('')
   })
 
+  test('shows events when a VTODO calendar-query fails', async ({ page, baseURL }) => {
+    await clearState(page)
+    await seedAccount(page, {
+      id: 'mock-account',
+      name: 'Mock Radicale',
+      serverUrl: `${baseURL}/mock-caldav/dav/`,
+      username: 'user',
+      password: 'pass',
+    })
+
+    const day = new Date().toISOString().slice(0, 10).replaceAll('-', '')
+    const calendarUrl = `${baseURL}/mock-caldav/dav/calendars/user/personal/`
+    await page.request.put(`${calendarUrl}partial-vevent.ics`, {
+      data: `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:partial-vevent
+DTSTART:${day}T120000Z
+DTEND:${day}T130000Z
+SUMMARY:Survives VTODO query failure
+END:VEVENT
+END:VCALENDAR`,
+    })
+
+    await page.request.post(
+      `${baseURL}/mock-caldav/__test__/fail?method=REPORT&prefix=${encodeURIComponent(
+        '/dav/calendars/user/personal/'
+      )}&count=5&body=VTODO`
+    )
+
+    await page.goto('/month')
+    const syncAll = page.locator('[data-component="sync-all-calendars"]')
+    await expect(syncAll).toBeEnabled({ timeout: 10_000 })
+    await syncAll.click()
+    await expect(page.getByText('Survives VTODO query failure').first()).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
   test('edits a recurring event at its original CalDAV href without duplicating it', async ({
     page,
     baseURL,

--- a/e2e/fixtures/vite-caldav-mock.ts
+++ b/e2e/fixtures/vite-caldav-mock.ts
@@ -29,7 +29,9 @@ import type { AddressInfo } from 'node:net'
  *                                            → 204; the next N matching
  *                                              requests return 500 (fault
  *                                              injection for partial-failure
- *                                              tests).
+ *                                              tests). Optional `body=`
+ *                                              matches a substring of a
+ *                                              REPORT body (e.g. VTODO).
  *   - GET  /.well-known/caldav                → 301 redirect to /mock-caldav/dav/
  *   - PROPFIND /mock-caldav/dav/              → 207 with current-user-principal
  *   - PROPFIND /dav/principals/...            → 207 with calendar-home-set
@@ -298,6 +300,8 @@ interface FaultRule {
   method: string
   prefix: string
   remaining: number
+  /** When set, only REPORT bodies containing this substring match. */
+  bodyIncludes?: string
 }
 
 export function caldavMockPlugin(): Plugin {
@@ -524,6 +528,7 @@ export function caldavMockPlugin(): Plugin {
           method: (params.get('method') ?? 'DELETE').toUpperCase(),
           prefix: params.get('prefix') ?? '/dav/',
           remaining: Number(params.get('count') ?? '1'),
+          bodyIncludes: params.get('body') ?? undefined,
         })
         res.writeHead(204)
         res.end()
@@ -578,9 +583,11 @@ export function caldavMockPlugin(): Plugin {
         return
       }
 
-      // Fault check — runs before any real handling below.
+      // Fault check — runs before any real handling below. REPORT faults that
+      // match on body wait until the body is read (see calendar-query handler).
       const fault = faults.find(
-        (f) => f.method === method && path.startsWith(f.prefix) && f.remaining > 0
+        (f) =>
+          f.method === method && path.startsWith(f.prefix) && f.remaining > 0 && !f.bodyIncludes
       )
       if (fault) {
         fault.remaining -= 1
@@ -720,7 +727,23 @@ export function caldavMockPlugin(): Plugin {
           reportBody += chunk
         })
         req.on('end', () => {
-          if (!reportBody.includes('sync-collection')) return calendarQueryReport(prefix, reportBody)
+          const bodyFault = faults.find(
+            (f) =>
+              f.method === 'REPORT' &&
+              path.startsWith(f.prefix) &&
+              f.remaining > 0 &&
+              Boolean(f.bodyIncludes) &&
+              reportBody.includes(f.bodyIncludes as string)
+          )
+          if (bodyFault) {
+            bodyFault.remaining -= 1
+            if (bodyFault.remaining <= 0) faults.splice(faults.indexOf(bodyFault), 1)
+            res.writeHead(500, { 'Content-Type': 'text/plain' })
+            res.end('injected failure')
+            return
+          }
+          if (!reportBody.includes('sync-collection'))
+            return calendarQueryReport(prefix, reportBody)
 
           if (owningCollection.rejectSyncToken) {
             res.writeHead(400, { 'Content-Type': 'text/plain' })

--- a/src/__tests__/headless.test.ts
+++ b/src/__tests__/headless.test.ts
@@ -18,9 +18,13 @@ vi.mock('@/features/caldav/client/credentials', () => ({
   getAllCredentials: () => mockGetAllCredentials(),
 }))
 
-vi.mock('@/features/caldav/client/CalDAVClient', () => ({
-  createCalDAVClient: (...args: unknown[]) => mockCreateClient(...args),
-}))
+vi.mock('@/features/caldav/client/CalDAVClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/caldav/client/CalDAVClient')>()
+  return {
+    ...actual,
+    createCalDAVClient: (...args: unknown[]) => mockCreateClient(...args),
+  }
+})
 
 vi.mock('@/features/caldav/adapter/iCalendarAdapter', () => ({
   parseICALDataAsync: (data: string, calendarId: string) => mockParse(data, calendarId),

--- a/src/features/caldav/client/CalDAVClient.ts
+++ b/src/features/caldav/client/CalDAVClient.ts
@@ -260,6 +260,28 @@ async function fetchWithTimeout(url: RequestInfo | URL, init?: RequestInit): Pro
   }
 }
 
+export interface FetchedCalendarObject {
+  url: string
+  data: string
+  etag?: string
+}
+
+export interface FetchEventsResult {
+  objects: FetchedCalendarObject[]
+  /** True when at least one VEVENT/VTODO/VJOURNAL REPORT failed. */
+  hadComponentFailures: boolean
+}
+
+/** Accept the structured result or a bare array (test mocks). */
+export function unwrapFetchEvents(
+  result: FetchEventsResult | FetchedCalendarObject[]
+): FetchEventsResult {
+  if (Array.isArray(result)) {
+    return { objects: result, hadComponentFailures: false }
+  }
+  return result
+}
+
 export class CalDAVClient {
   private client: Awaited<ReturnType<typeof createDAVClient>> | null = null
   // Cache of raw DAV calendar objects from tsdav, keyed by URL matching.
@@ -427,7 +449,7 @@ export class CalDAVClient {
     start: string,
     end: string,
     includeAllEvents = false
-  ): Promise<{ url: string; data: string; etag?: string }[]> {
+  ): Promise<FetchEventsResult> {
     if (!navigator.onLine) {
       throw new Error('No network connection. Please check your internet connection.')
     }
@@ -478,10 +500,37 @@ export class CalDAVClient {
     if (supports('VTODO')) requests.push(componentRequest('VTODO'))
     if (supports('VJOURNAL')) requests.push(componentRequest('VJOURNAL'))
 
-    const allItems = (await Promise.all(requests)).flat()
+    // VEVENT/VTODO/VJOURNAL are independent listings. Promise.all would drop
+    // events if an empty VTODO query (or a timeout) threw. Fail closed only
+    // when every requested component query fails — a partial listing must not
+    // be treated as authoritative for remote deletions.
+    const settled = await Promise.allSettled(requests)
+    const fulfilled = settled.filter(
+      (
+        result
+      ): result is PromiseFulfilledResult<Array<{ url: string; data?: unknown; etag?: string }>> =>
+        result.status === 'fulfilled'
+    )
+    const rejected = settled.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    )
+
+    if (fulfilled.length === 0 && rejected.length > 0) {
+      const reason = rejected[0].reason
+      throw reason instanceof Error ? reason : new Error(String(reason))
+    }
+
+    if (rejected.length > 0) {
+      console.warn(
+        '[CalDAV] Component query failed; calendar listing is incomplete',
+        rejected.map((result) => result.reason)
+      )
+    }
+
+    const allItems = fulfilled.flatMap((result) => result.value)
 
     // Remove duplicates by URL - store raw server URLs consistently
-    const uniqueByUrl = new Map<string, { url: string; data: string; etag?: string }>()
+    const uniqueByUrl = new Map<string, FetchedCalendarObject>()
     for (const obj of allItems) {
       if (typeof obj.url !== 'string' || typeof obj.data !== 'string') continue
       if (!uniqueByUrl.has(obj.url)) {
@@ -493,7 +542,10 @@ export class CalDAVClient {
       }
     }
 
-    return Array.from(uniqueByUrl.values())
+    return {
+      objects: Array.from(uniqueByUrl.values()),
+      hadComponentFailures: rejected.length > 0,
+    }
   }
 
   /**

--- a/src/features/caldav/client/__tests__/CalDAVClient.test.ts
+++ b/src/features/caldav/client/__tests__/CalDAVClient.test.ts
@@ -497,9 +497,10 @@ END:VCALENDAR`,
 
       expect(mockClientMethods.fetchCalendarObjects).toHaveBeenCalledTimes(3)
 
-      expect(result).toHaveLength(2)
-      expect(result.find((obj) => obj.url === mockEventObject.url)).toBeDefined()
-      expect(result.find((obj) => obj.url === mockTodoObject.url)).toBeDefined()
+      expect(result.hadComponentFailures).toBe(false)
+      expect(result.objects).toHaveLength(2)
+      expect(result.objects.find((obj) => obj.url === mockEventObject.url)).toBeDefined()
+      expect(result.objects.find((obj) => obj.url === mockTodoObject.url)).toBeDefined()
     })
 
     it('skips reports for components the calendar does not advertise', async () => {
@@ -516,7 +517,7 @@ END:VCALENDAR`,
       )
 
       expect(mockClientMethods.fetchCalendarObjects).toHaveBeenCalledTimes(1)
-      expect(result).toEqual([mockEventObject])
+      expect(result).toEqual({ objects: [mockEventObject], hadComponentFailures: false })
     })
 
     it('uses timeRange filter for VEVENTs', async () => {
@@ -605,7 +606,7 @@ END:VCALENDAR`,
         '2024-12-31T23:59:59Z'
       )
 
-      expect(result).toHaveLength(1)
+      expect(result.objects).toHaveLength(1)
     })
 
     it('returns empty array when no events or tasks found', async () => {
@@ -622,7 +623,8 @@ END:VCALENDAR`,
         '2024-12-31T23:59:59Z'
       )
 
-      expect(result).toHaveLength(0)
+      expect(result.objects).toHaveLength(0)
+      expect(result.hadComponentFailures).toBe(false)
     })
 
     // Bug 16: calendar lookup uses raw URL matching
@@ -640,7 +642,7 @@ END:VCALENDAR`,
         '2024-12-31T23:59:59Z'
       )
 
-      expect(result).toHaveLength(1)
+      expect(result.objects).toHaveLength(1)
     })
 
     // Bug 16: event URLs should be raw, not proxy-prefixed
@@ -663,8 +665,8 @@ END:VCALENDAR`,
         '2024-12-31T23:59:59Z'
       )
 
-      expect(result[0].url).toBe(mockEventObject.url)
-      expect(result[0].url).not.toContain('proxy.example.com')
+      expect(result.objects[0].url).toBe(mockEventObject.url)
+      expect(result.objects[0].url).not.toContain('proxy.example.com')
     })
 
     // Bug 20: offline detection
@@ -675,6 +677,36 @@ END:VCALENDAR`,
       await expect(
         client.fetchEvents(mockCalendar.url, '2024-01-01T00:00:00Z', '2024-12-31T23:59:59Z')
       ).rejects.toThrow('No network connection')
+    })
+
+    it('keeps VEVENTs when a VTODO query throws', async () => {
+      await client.connect()
+
+      mockClientMethods.fetchCalendarObjects
+        .mockResolvedValueOnce([mockEventObject])
+        .mockRejectedValueOnce(new Error('Collection query failed: 404'))
+        .mockResolvedValueOnce([])
+
+      const result = await client.fetchEvents(
+        mockCalendar.url,
+        '2024-01-01T00:00:00Z',
+        '2024-12-31T23:59:59Z'
+      )
+
+      expect(result.hadComponentFailures).toBe(true)
+      expect(result.objects).toEqual([mockEventObject])
+    })
+
+    it('throws when every component query fails', async () => {
+      await client.connect()
+
+      mockClientMethods.fetchCalendarObjects.mockRejectedValue(
+        new Error('Collection query failed: 504')
+      )
+
+      await expect(
+        client.fetchEvents(mockCalendar.url, '2024-01-01T00:00:00Z', '2024-12-31T23:59:59Z')
+      ).rejects.toThrow('Collection query failed: 504')
     })
   })
 

--- a/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
+++ b/src/features/caldav/hooks/__tests__/useCalDAV.test.ts
@@ -13,7 +13,13 @@ vi.mock('../../client/discovery')
 vi.mock('../../client/credentials')
 vi.mock('../../sync/accountStorage')
 vi.mock('../../adapter/iCalendarAdapter')
-vi.mock('../../client/CalDAVClient')
+vi.mock('../../client/CalDAVClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../client/CalDAVClient')>()
+  return {
+    ...actual,
+    createCalDAVClient: vi.fn(),
+  }
+})
 vi.mock('../../sync/syncEngine', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../sync/syncEngine')>()
   return {
@@ -2261,6 +2267,32 @@ describe('useCalDAV', () => {
 
       // The server event should have been added
       expect(store.events.find((e) => e.id === 'server-evt-1')).toBeDefined()
+    })
+
+    it('does not delete local events when a component query failed', async () => {
+      act(() => {
+        useCalendarStore.getState().addEvent({ ...mockEvent, id: 'local-kept' })
+      })
+      const serverEvent = { ...mockEvent, id: 'server-evt-1', title: 'From server' }
+      const iCalendarAdapter = await import('../../adapter/iCalendarAdapter')
+      vi.mocked(iCalendarAdapter.parseICALData).mockReturnValue([serverEvent])
+      mockCalDAVClient.createCalDAVClient.mockResolvedValue({
+        fetchEvents: vi.fn().mockResolvedValue({
+          objects: [{ url: 'https://...', data: 'ical-data', etag: 'etag1' }],
+          hadComponentFailures: true,
+        }),
+        fetchCalendars: vi.fn().mockResolvedValue([mockCalendar]),
+      } as any)
+
+      const { result } = renderHook(() => useCalDAV())
+      await waitFor(() => expect(result.current.accounts.length).toBe(1))
+      await act(async () => {
+        await result.current.syncAccount('acc-1')
+      })
+
+      const ids = useCalendarStore.getState().events.map((e) => e.id)
+      expect(ids).toContain('local-kept')
+      expect(ids).toContain('server-evt-1')
     })
 
     it('keeps local changes that are still waiting to be pushed', async () => {

--- a/src/features/caldav/hooks/useCalDAV.ts
+++ b/src/features/caldav/hooks/useCalDAV.ts
@@ -14,7 +14,7 @@ import type {
   DeleteHrefPendingData,
   PendingChange,
 } from '../types'
-import { createCalDAVClient } from '../client/CalDAVClient'
+import { createCalDAVClient, unwrapFetchEvents } from '../client/CalDAVClient'
 import type { SyncCollectionChange } from '../client/CalDAVClient'
 import { probeConnection, expandProviderUrl, type ProbeResult } from '../client/discovery'
 import { CalDAVConnectionError } from '../client/errors'
@@ -1101,7 +1101,9 @@ export function useCalDAVInstance(): UseCalDAVReturn {
           CALDAV_FETCH_CONCURRENCY,
           async (cal) => {
             console.log('[CalDAV] addAccount: fetching events for', cal.name, cal.url)
-            const fetchedEvents = await client.fetchEvents(cal.url, start, end)
+            const { objects: fetchedEvents } = unwrapFetchEvents(
+              await client.fetchEvents(cal.url, start, end)
+            )
             progressDone++
             reportProgress({ done: progressDone })
             console.log(
@@ -1584,6 +1586,7 @@ export function useCalDAVInstance(): UseCalDAVReturn {
             const touchedHrefs: Set<string> | null = changes ? new Set<string>() : null
             const removedHrefs = new Set<string>()
             let fetchedEvents: { url: string; data: string; etag?: string }[]
+            let hadComponentFailures = false
 
             if (changes) {
               for (const change of changes) {
@@ -1642,8 +1645,12 @@ export function useCalDAVInstance(): UseCalDAVReturn {
                   storedToken ? ' (sync token unusable)' : ' (no stored sync token)'
                 }`
               )
-              fetchedEvents = await client.fetchEvents(cal.url, start, end, true)
-              fullyListedCalendarIds.add(cal.id)
+              const fetched = unwrapFetchEvents(await client.fetchEvents(cal.url, start, end, true))
+              fetchedEvents = fetched.objects
+              hadComponentFailures = fetched.hadComponentFailures
+              if (!hadComponentFailures) {
+                fullyListedCalendarIds.add(cal.id)
+              }
             }
 
             // Snapshot pending local changes after the network fetch, as late as
@@ -1794,7 +1801,7 @@ export function useCalDAVInstance(): UseCalDAVReturn {
             // back for it) and a changed resource that no longer contains a
             // component it used to — a deleted recurrence override, say.
             // Every other local event is simply not covered by this REPORT.
-            if (!hadParseFailures) {
+            if (!hadParseFailures && !hadComponentFailures) {
               const deletionCandidates = touchedHrefs
                 ? calendarEvents.filter(
                     (e) => e.resourceHref && touchedHrefs.has(hrefKey(e.resourceHref))
@@ -1821,10 +1828,15 @@ export function useCalDAVInstance(): UseCalDAVReturn {
             } else {
               // Reconciliation is incomplete, so the cursors stay where they
               // are: advancing them would retire the server's only mention of
-              // a resource we could not read. A body that failed to parse is
-              // never a deletion — it is retried next cycle.
+              // a resource we could not read. A body that failed to parse, or
+              // a component REPORT that threw, is never a deletion — it is
+              // retried next cycle.
               console.warn(
-                `[CalDAV] Skipping remote-deletion reconciliation for calendar ${cal.id}: one or more resources failed to parse this cycle.`
+                `[CalDAV] Skipping remote-deletion reconciliation for calendar ${cal.id}: ${
+                  hadComponentFailures
+                    ? 'one or more component queries failed this cycle.'
+                    : 'one or more resources failed to parse this cycle.'
+                }`
               )
             }
 

--- a/src/features/caldav/sync/syncEngine.ts
+++ b/src/features/caldav/sync/syncEngine.ts
@@ -1,6 +1,6 @@
 import type { CalendarEvent } from '@/types'
 import type { SyncResult, ConflictResolution } from '../types'
-import { CalDAVClient } from '../client/CalDAVClient'
+import { CalDAVClient, unwrapFetchEvents } from '../client/CalDAVClient'
 import {
   eventToICAL,
   eventsToICAL,
@@ -95,7 +95,9 @@ export class SyncEngine {
       throw new Error(`Calendar not found: ${this.calendarId}`)
     }
 
-    const serverEventsRaw = await this.client.fetchEvents(calendar.url, start, end, true)
+    const { objects: serverEventsRaw, hadComponentFailures } = unwrapFetchEvents(
+      await this.client.fetchEvents(calendar.url, start, end, true)
+    )
 
     const parsedEvents: CalendarEvent[] = []
     const allCategoryNames = new Set<string>()
@@ -171,9 +173,11 @@ export class SyncEngine {
       }
     }
 
-    for (const localEvent of existingEvents) {
-      if (!serverEventIds.has(localEvent.id)) {
-        result.deleted.push(localEvent.id)
+    if (!hadComponentFailures) {
+      for (const localEvent of existingEvents) {
+        if (!serverEventIds.has(localEvent.id)) {
+          result.deleted.push(localEvent.id)
+        }
       }
     }
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -27,7 +27,7 @@ import type { CalDAVCalendar } from '@/features/caldav/types'
 import { getHeadlessBridge } from '@/lib/headlessBridge'
 import { getAllAccounts, getAllCalendars } from '@/features/caldav/sync/accountStorage'
 import { getAllCredentials } from '@/features/caldav/client/credentials'
-import { createCalDAVClient } from '@/features/caldav/client/CalDAVClient'
+import { createCalDAVClient, unwrapFetchEvents } from '@/features/caldav/client/CalDAVClient'
 import { parseICALDataAsync } from '@/features/caldav/adapter/iCalendarAdapter'
 import { buildMirrorPayload, MIRROR_PAST_DAYS, MIRROR_FUTURE_DAYS } from '@/lib/calendarMirror'
 import { initHeadlessI18n } from '@/lib/i18nHeadless'
@@ -109,7 +109,9 @@ export async function runHeadlessSync(): Promise<HeadlessResult> {
         CALDAV_FETCH_CONCURRENCY,
         async (calendar) => {
           try {
-            const resources = await client.fetchEvents(calendar.url, rangeStart, rangeEnd)
+            const { objects: resources } = unwrapFetchEvents(
+              await client.fetchEvents(calendar.url, rangeStart, rangeEnd)
+            )
             return { calendar, resources }
           } catch (error) {
             bridge.log(


### PR DESCRIPTION
Fixes #134.

`fetchEvents` waited on VEVENT/VTODO/VJOURNAL with `Promise.all`, so one failed REPORT dropped the whole listing.

**Change:** `Promise.allSettled`; keep objects from queries that succeeded; throw only if every requested query fails; skip remote-deletion reconciliation (and cursor advance) when any component query failed — same idea as `hadParseFailures`.

**Verify:** `pnpm typecheck`; vitest on `CalDAVClient`, `useCalDAV`, `syncEngine`, and headless; Playwright `shows events when a VTODO calendar-query fails`.
