### PR TITLE
perf: parallelize release E2E checks

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -10,10 +10,12 @@ What to verify before cutting a release. The automated half is what
 pnpm audit                        # optional dependency vulnerability review
 ```
 
-The release script runs the full Playwright suite unless `--no-e2e` is passed,
-and runs the Docker build/probes unless `--no-docker` is passed. It picks the
-first free host port from 8080 up for the container checks; pin it with
-`HEALTH_PORT=…` if you need a specific one.
+The release script runs the full Playwright suite unless `--no-e2e` is passed.
+The three browser projects run concurrently with isolated app and DAV mock
+servers, one worker per browser, so they do not contend for the shared local
+test backend. It runs the Docker build/probes unless `--no-docker` is passed.
+It picks the first free host port from 8080 up for the container checks; pin it
+with `HEALTH_PORT=…` if you need a specific one.
 
 Then cut the release:
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -6,7 +6,7 @@ What to verify before cutting a release. The automated half is what
 ## Automated
 
 ```bash
-./scripts/release.sh --dry-run    # typecheck + lint + unit + E2E + build + Docker checks
+./scripts/release.sh --dry-run    # typecheck + lint + unit + E2E + Docker build/healthcheck
 pnpm audit                        # optional dependency vulnerability review
 ```
 
@@ -16,6 +16,15 @@ servers, one worker per browser, so they do not contend for the shared local
 test backend. It runs the Docker build/probes unless `--no-docker` is passed.
 It picks the first free host port from 8080 up for the container checks; pin it
 with `HEALTH_PORT=…` if you need a specific one.
+
+Running `./scripts/release.sh` without a release option only performs checks;
+it does not push source or images. `--dry-run` likewise never bumps, commits,
+tags, or pushes anything.
+
+When Docker or Podman is enabled, the Dockerfile performs the one production
+compilation used by the release image; the release script does not compile the
+bundle separately first. `--no-docker` keeps a local production build as a
+fallback, while `--docker-push` reuses the health-checked image when available.
 
 Then cut the release:
 

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -33,6 +33,10 @@ layouts. Vitest excludes E2E files and runs its unit tests in both
   CORS tests rather than a separate HTTP mock origin.
 - The E2E server uses port `5199`; the diagnostics fixture uses HTTPS port
   `8099`. Override them with `E2E_PORT` and `DAV_PORT` respectively.
+- Release checks use `scripts/run-e2e-projects.mjs`, which assigns each browser
+  its own app and DAV ports (`5200`/`8100` upward); HMR stays on each app's own
+  port. Shift those ranges with `E2E_PARALLEL_PORT_OFFSET` and
+  `DAV_PARALLEL_PORT_OFFSET` if a local service occupies one of them.
 - `index.html` permits `connect-src 'self' https:`. Custom HTTPS fixtures must
   account for that; the diagnostics fixture uses a self-signed certificate.
 - `page.addInitScript()` runs on every navigation, including reloads. Seed

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
   // Costs ~4.6m against ~2.3m; override with `--workers=N` for a quick loop.
   workers: 2,
   reporter: IS_CI ? [['github'], ['list']] : [['list']],
-  outputDir: './e2e/test-results',
+  outputDir: process.env.PLAYWRIGHT_OUTPUT_DIR ?? './e2e/test-results',
   timeout: 30_000,
   // 10s, not Playwright's 5s default. Nearly every assertion in this suite is
   // an eventual-consistency wait — a sync landing, a persisted store

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,7 @@ const PORT = Number(process.env.E2E_PORT ?? 5199)
 const BASE_URL = `http://localhost:${PORT}`
 const DAV_PORT = Number(process.env.DAV_PORT ?? 8099)
 const IS_CI = !!process.env.CI
+const IS_PARALLEL_RUNNER = process.env.PLAYWRIGHT_PARALLEL_RUNNER === '1'
 
 export default defineConfig({
   testDir: './e2e',
@@ -71,7 +72,7 @@ export default defineConfig({
     {
       command: `CALINO_E2E_MOCK=1 pnpm dev --port ${PORT} --strictPort`,
       url: BASE_URL,
-      reuseExistingServer: !IS_CI,
+      reuseExistingServer: !IS_CI && !IS_PARALLEL_RUNNER,
       timeout: 120_000,
       stdout: 'ignore',
       stderr: 'pipe',
@@ -86,7 +87,7 @@ export default defineConfig({
       command: `node e2e/fixtures/dav-server.mjs`,
       url: `https://localhost:${DAV_PORT}/good/`,
       ignoreHTTPSErrors: true,
-      reuseExistingServer: !IS_CI,
+      reuseExistingServer: !IS_CI && !IS_PARALLEL_RUNNER,
       timeout: 30_000,
       stdout: 'ignore',
       stderr: 'pipe',

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -112,6 +112,28 @@ fi
 
 REPO=$(git remote get-url origin | sed 's/.*github.com[:/]\(.\+\)\.git$/\1/')
 
+DOCKER_TEST_CONTAINER_STARTED=false
+DOCKER_TEST_IMAGE_BUILT=false
+DOCKER_TEST_IMAGE_EXISTED=false
+DOCKER_TEST_IMAGE_ORIGINAL_ID=""
+
+cleanup_docker_test_image() {
+  if [ "$DOCKER_TEST_IMAGE_BUILT" = true ]; then
+    $ENGINE rmi calino:test > /dev/null 2>&1 || true
+    if [ "$DOCKER_TEST_IMAGE_EXISTED" = true ] && [ -n "$DOCKER_TEST_IMAGE_ORIGINAL_ID" ]; then
+      $ENGINE tag "$DOCKER_TEST_IMAGE_ORIGINAL_ID" calino:test > /dev/null 2>&1 || true
+    fi
+    DOCKER_TEST_IMAGE_BUILT=false
+  fi
+}
+
+cleanup_docker_artifacts() {
+  if [ "$DOCKER_TEST_CONTAINER_STARTED" = true ]; then
+    $ENGINE rm -f calino-release-test > /dev/null 2>&1 || true
+  fi
+  cleanup_docker_test_image
+}
+
 # ─── Version restore on abort ─────────────────────────────────────────────────
 # The bump has to happen before the build, since `pnpm build` bakes
 # __APP_VERSION__ into the bundle and the Docker image — testing an image
@@ -121,9 +143,11 @@ REPO=$(git remote get-url origin | sed 's/.*github.com[:/]\(.\+\)\.git$/\1/')
 # doesn't reach the commit.
 PKG_BACKUP=$(mktemp)
 CHANGELOG_BACKUP=$(mktemp)
+SAMPLE_EVENTS_BACKUP=$(mktemp)
 BUMPED=false
 CHANGELOG_PROMOTED=false
 COMMITTED=false
+SAMPLE_EVENTS_BACKED_UP=false
 
 restore_version() {
   if [ "$COMMITTED" = false ]; then
@@ -139,9 +163,12 @@ restore_version() {
       warn "CHANGELOG.md restored — '## [Unreleased]' put back"
     fi
   fi
-  rm -f "$PKG_BACKUP" "$CHANGELOG_BACKUP"
+  if [ "$SAMPLE_EVENTS_BACKED_UP" = true ]; then
+    cp "$SAMPLE_EVENTS_BACKUP" public/sample-events.ics
+  fi
+  rm -f "$PKG_BACKUP" "$CHANGELOG_BACKUP" "$SAMPLE_EVENTS_BACKUP"
 }
-trap restore_version EXIT
+trap 'cleanup_docker_artifacts; restore_version' EXIT
 
 # ─── Changelog extraction ─────────────────────────────────────────────────────
 # Pull the "## [x.y.z]" section out of CHANGELOG.md so the GitHub Release shows
@@ -322,9 +349,20 @@ if [ -n "$RELEASE_VERSION" ] && [ -z "$(extract_changelog "$RELEASE_VERSION")" ]
 fi
 
 # ─── Build ─────────────────────────────────────────────────────────────────────
-step "Build"
-pnpm build
-ok "Build succeeded"
+# With Docker enabled, the Dockerfile's build stage is the production build.
+# Running it here first would compile the same bundle twice. Keep a standalone
+# build for --no-docker checks, unless --docker-push will build the image below.
+if [ "$SKIP_DOCKER" = true ] && [ "$DOCKER_PUSH" = false ]; then
+  step "Build"
+  if [ "$DRY_RUN" = true ]; then
+    # `pnpm build` refreshes the checked-in sample calendar as part of its
+    # normal work. A dry run must leave the working tree byte-for-byte intact.
+    cp public/sample-events.ics "$SAMPLE_EVENTS_BACKUP"
+    SAMPLE_EVENTS_BACKED_UP=true
+  fi
+  pnpm build
+  ok "Build succeeded"
+fi
 
 # ─── Docker ────────────────────────────────────────────────────────────────────
 if [ "$SKIP_DOCKER" = false ]; then
@@ -335,9 +373,19 @@ if [ "$SKIP_DOCKER" = false ]; then
     fail "$ENGINE is not running. Start it, or use --no-docker"
   fi
 
+  # Preserve a caller-owned test tag while using the same name for the
+  # release check. The original image is restored by the EXIT cleanup after
+  # the tested image has been discarded.
+  if DOCKER_TEST_IMAGE_ORIGINAL_ID=$($ENGINE image inspect --format '{{.Id}}' calino:test 2>/dev/null); then
+    DOCKER_TEST_IMAGE_EXISTED=true
+  fi
+
   # Output is captured rather than discarded: `set -e` would otherwise abort
   # the whole release on a build failure having printed nothing at all, which
   # is the least useful way to learn the Dockerfile broke.
+  # Claim the temporary tag before starting the build so an interruption at
+  # any point still restores a pre-existing calino:test tag in the EXIT trap.
+  DOCKER_TEST_IMAGE_BUILT=true
   BUILD_STATUS=0
   BUILD_OUTPUT=$($ENGINE build -t calino:test . 2>&1) || BUILD_STATUS=$?
   if [ "$BUILD_STATUS" -ne 0 ]; then
@@ -356,15 +404,19 @@ if [ "$SKIP_DOCKER" = false ]; then
   # instead of the container and the check reports nonsense.
   probe() { curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$HEALTH_PORT$1" 2>/dev/null || true; }
 
-  # An earlier aborted run can leave the container alive and holding the port,
-  # which would otherwise trip the conflict check below with a misleading message.
-  $ENGINE rm -f calino-release-test > /dev/null 2>&1 || true
+  # Never remove a container we did not create. The EXIT trap cleans up a
+  # container started by this run; an older or caller-owned one needs explicit
+  # attention instead of being silently destroyed.
+  if $ENGINE inspect calino-release-test > /dev/null 2>&1; then
+    fail "Container calino-release-test already exists. Stop it, or use another release-check setup"
+  fi
 
   # Fail loudly on a port conflict rather than silently testing the squatter.
   if [ "$(probe /)" != "000" ]; then
     fail "Something is already serving on port $HEALTH_PORT. Stop it, or pin another port with HEALTH_PORT=..."
   fi
 
+  DOCKER_TEST_CONTAINER_STARTED=true
   $ENGINE run -d --name calino-release-test -p "$HEALTH_PORT:8080" calino:test > /dev/null
 
   # Wait for container to be healthy
@@ -397,7 +449,10 @@ if [ "$SKIP_DOCKER" = false ]; then
   fi
 
   $ENGINE rm -f calino-release-test > /dev/null 2>&1
-  $ENGINE rmi calino:test > /dev/null 2>&1
+  DOCKER_TEST_CONTAINER_STARTED=false
+  if [ "$DOCKER_PUSH" = false ] || [ "$DRY_RUN" = true ]; then
+    cleanup_docker_test_image
+  fi
   ok "Container healthcheck passed"
 
   # Show what tags CI will generate
@@ -410,7 +465,7 @@ if [ "$SKIP_DOCKER" = false ]; then
 fi
 
 # ─── Docker push to GHCR ──────────────────────────────────────────────────────
-if [ "$DOCKER_PUSH" = true ]; then
+if [ "$DOCKER_PUSH" = true ] && [ "$DRY_RUN" = false ]; then
   step "Pushing image to GHCR ($ENGINE)"
 
   if ! $ENGINE info > /dev/null 2>&1; then
@@ -428,14 +483,30 @@ if [ "$DOCKER_PUSH" = true ]; then
   SHA_TAG="sha-$(git rev-parse --short HEAD)"
   IMAGE="ghcr.io/ivan-malinovski/calino"
 
-  # Build with all tags
-  step "Building with tags: main, latest, $VERSION_TAG, $SHA_TAG"
-  $ENGINE build \
-    -t "$IMAGE:main" \
-    -t "$IMAGE:latest" \
-    -t "$IMAGE:$VERSION_TAG" \
-    -t "$IMAGE:$SHA_TAG" \
-    .
+  if [ "$SKIP_DOCKER" = false ]; then
+    # The image just passed the container healthcheck; tag that exact image
+    # instead of compiling the application again for the registry tags.
+    step "Tagging tested image: main, latest, $VERSION_TAG, $SHA_TAG"
+    $ENGINE tag calino:test "$IMAGE:main"
+    $ENGINE tag calino:test "$IMAGE:latest"
+    $ENGINE tag calino:test "$IMAGE:$VERSION_TAG"
+    $ENGINE tag calino:test "$IMAGE:$SHA_TAG"
+  else
+    # With --no-docker there is no health-checked image to reuse, so the push
+    # build remains the single production compilation for this path.
+    step "Building with tags: main, latest, $VERSION_TAG, $SHA_TAG"
+    BUILD_STATUS=0
+    BUILD_OUTPUT=$($ENGINE build \
+      -t "$IMAGE:main" \
+      -t "$IMAGE:latest" \
+      -t "$IMAGE:$VERSION_TAG" \
+      -t "$IMAGE:$SHA_TAG" \
+      . 2>&1) || BUILD_STATUS=$?
+    if [ "$BUILD_STATUS" -ne 0 ]; then
+      echo "$BUILD_OUTPUT"
+      fail "$ENGINE build failed (exit $BUILD_STATUS)"
+    fi
+  fi
 
   # Push all tags
   step "Pushing tags"
@@ -444,6 +515,10 @@ if [ "$DOCKER_PUSH" = true ]; then
   $ENGINE push "$IMAGE:$VERSION_TAG"
   $ENGINE push "$IMAGE:$SHA_TAG"
 
+  if [ "$SKIP_DOCKER" = false ]; then
+    cleanup_docker_test_image
+  fi
+
   ok "Image pushed to GHCR"
   echo ""
   echo "  Tags pushed:"
@@ -451,6 +526,8 @@ if [ "$DOCKER_PUSH" = true ]; then
   echo "    - $IMAGE:latest"
   echo "    - $IMAGE:$VERSION_TAG"
   echo "    - $IMAGE:$SHA_TAG"
+elif [ "$DOCKER_PUSH" = true ]; then
+  warn "Dry run — skipping Docker image push"
 fi
 
 # ─── Commit & push ─────────────────────────────────────────────────────────────
@@ -467,7 +544,11 @@ if [ "$DRY_RUN" = false ] && { [ "$BUMPED" = true ] || [ "$CHANGELOG_PROMOTED" =
   ok "Release preparation committed"
 fi
 
-if [ "$SKIP_PUSH" = false ]; then
+if [ "$SKIP_PUSH" = false ] && {
+  [ -n "$RELEASE_VERSION" ] ||
+  [ "$BUMPED" = true ] ||
+  [ "$CHANGELOG_PROMOTED" = true ]
+}; then
   step "Pushing to $BRANCH"
   git push origin "$BRANCH"
 
@@ -516,6 +597,8 @@ if [ "$SKIP_PUSH" = false ]; then
   fi
 
   ok "Pushed to $BRANCH"
+elif [ "$SKIP_PUSH" = false ]; then
+  echo "  No release commit to push"
 fi
 
 # ─── Done ──────────────────────────────────────────────────────────────────────

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -261,7 +261,7 @@ ok "All tests passed"
 # Those only fail in a browser, so a release check without e2e is not a check.
 if [ "$SKIP_E2E" = false ]; then
   step "End-to-end tests"
-  pnpm test:e2e
+  node scripts/run-e2e-projects.mjs
   ok "End-to-end tests passed"
 else
   warn "Skipping end-to-end tests (--no-e2e)"

--- a/scripts/run-e2e-projects.mjs
+++ b/scripts/run-e2e-projects.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+/**
+ * Run Playwright's browser projects concurrently without making them share
+ * the Vite/CalDAV mock server. The normal `pnpm test:e2e` command remains the
+ * convenient single-server developer run; release checks use this runner so
+ * one browser's state and server load cannot slow or perturb another.
+ */
+import { spawn } from 'node:child_process'
+
+const projects = [
+  { name: 'chromium', appPort: 5200, davPort: 8100 },
+  { name: 'firefox', appPort: 5201, davPort: 8101 },
+  { name: 'webkit', appPort: 5202, davPort: 8102 },
+]
+
+const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+const extraArgs = process.argv.slice(2)
+const appPortOffset = Number(process.env.E2E_PARALLEL_PORT_OFFSET ?? 0)
+const davPortOffset = Number(process.env.DAV_PARALLEL_PORT_OFFSET ?? 0)
+const outputRoot = process.env.PLAYWRIGHT_OUTPUT_ROOT ?? 'e2e/test-results'
+const children = new Set()
+const outputBuffers = new Map()
+let interrupted = false
+
+function terminate(child, signal) {
+  if (!child.pid) return
+  if (process.platform === 'win32') {
+    child.kill(signal)
+    return
+  }
+
+  // Each child is detached below, so killing its process group also stops the
+  // Vite and DAV servers spawned by Playwright when the caller is interrupted.
+  try {
+    process.kill(-child.pid, signal)
+  } catch {
+    child.kill(signal)
+  }
+}
+
+function prefix(project, channel, stream, chunk) {
+  const key = `${project}:${channel}`
+  const text = (outputBuffers.get(key) ?? '') + chunk.toString()
+  const lines = text.split('\n')
+  outputBuffers.set(key, lines.pop() ?? '')
+  for (const line of lines) stream.write(`[${project}] ${line}\n`)
+}
+
+function flush(project) {
+  for (const channel of ['stdout', 'stderr']) {
+    const key = `${project}:${channel}`
+    const line = outputBuffers.get(key)
+    if (line) process[channel].write(`[${project}] ${line}\n`)
+    outputBuffers.delete(key)
+  }
+}
+
+function runProject(project) {
+  const appPort = project.appPort + appPortOffset
+  const davPort = project.davPort + davPortOffset
+  const outputDir = `${outputRoot}/${project.name}`
+  const child = spawn(
+    pnpm,
+    [
+      'exec',
+      'playwright',
+      'test',
+      `--project=${project.name}`,
+      '--workers=1',
+      ...extraArgs,
+    ],
+    {
+      detached: process.platform !== 'win32',
+      env: {
+        ...process.env,
+        // Vite keeps HMR on this server's unique app port when the host is
+        // explicit, avoiding a shared default HMR port across projects.
+        CALINO_DEV_HOST: 'localhost',
+        E2E_PORT: String(appPort),
+        DAV_PORT: String(davPort),
+        PLAYWRIGHT_OUTPUT_DIR: outputDir,
+      },
+      stdio: ['inherit', 'pipe', 'pipe'],
+    }
+  )
+
+  children.add(child)
+  child.stdout.on('data', (chunk) => prefix(project.name, 'stdout', process.stdout, chunk))
+  child.stderr.on('data', (chunk) => prefix(project.name, 'stderr', process.stderr, chunk))
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (result) => {
+      if (settled) return
+      settled = true
+      flush(project.name)
+      children.delete(child)
+      resolve(result)
+    }
+
+    child.once('error', (error) => {
+      prefix(project.name, 'stderr', process.stderr, `failed to start: ${error.message}\n`)
+      finish({ project: project.name, code: 1 })
+    })
+    child.once('close', (code, signal) => {
+      finish({
+        project: project.name,
+        code: interrupted ? 130 : code ?? 1,
+        signal,
+      })
+    })
+  })
+}
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.once(signal, () => {
+    interrupted = true
+    for (const child of children) terminate(child, signal)
+  })
+}
+
+console.log(`Running ${projects.length} Playwright projects concurrently (one worker each)`)
+const results = await Promise.all(projects.map(runProject))
+const failures = results.filter(({ code }) => code !== 0)
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} Playwright project(s) failed: ${failures.map(({ project }) => project).join(', ')}`)
+  process.exitCode = 1
+} else {
+  console.log('\nAll Playwright projects passed')
+}

--- a/scripts/run-e2e-projects.mjs
+++ b/scripts/run-e2e-projects.mjs
@@ -6,7 +6,8 @@
  * convenient single-server developer run; release checks use this runner so
  * one browser's state and server load cannot slow or perturb another.
  */
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
+import net from 'node:net'
 
 const projects = [
   { name: 'chromium', appPort: 5200, davPort: 8100 },
@@ -21,12 +22,19 @@ const davPortOffset = Number(process.env.DAV_PARALLEL_PORT_OFFSET ?? 0)
 const outputRoot = process.env.PLAYWRIGHT_OUTPUT_ROOT ?? 'e2e/test-results'
 const children = new Set()
 const outputBuffers = new Map()
+const childProjects = new Map()
 let interrupted = false
+let failureDetected = false
 
 function terminate(child, signal) {
   if (!child.pid) return
   if (process.platform === 'win32') {
-    child.kill(signal)
+    // `ChildProcess.kill` only targets pnpm.cmd on Windows. taskkill's tree
+    // switch also stops Playwright, Vite, and DAV descendants.
+    const result = spawnSync('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], {
+      stdio: 'ignore',
+    })
+    if (result.error || result.status !== 0) child.kill(signal)
     return
   }
 
@@ -37,6 +45,123 @@ function terminate(child, signal) {
   } catch {
     child.kill(signal)
   }
+}
+
+function portIsFree(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(port, () => server.close(() => resolve(true)))
+  })
+}
+
+function portListenerPids(port) {
+  if (process.platform === 'win32') {
+    const script = `$ErrorActionPreference = 'SilentlyContinue'; Get-NetTCPConnection -State Listen -LocalPort ${port} | Select-Object -ExpandProperty OwningProcess`
+    const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return (result.stdout ?? '').trim().split(/\s+/).filter(Boolean)
+  }
+
+  const result = spawnSync('lsof', [`-tiTCP:${port}`, '-sTCP:LISTEN'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  })
+  return (result.stdout ?? '').trim().split(/\s+/).filter(Boolean)
+}
+
+function isDescendant(pid, rootPid) {
+  if (pid === String(rootPid)) return true
+
+  if (process.platform === 'win32') {
+    const script = `$root = ${rootPid}; $current = ${pid}; while ($current -and $current -ne 0) { $process = Get-CimInstance Win32_Process -Filter \"ProcessId = $current\"; if (-not $process) { break }; if ($process.ParentProcessId -eq $root) { exit 0 }; $current = $process.ParentProcessId }; exit 1`
+    const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      stdio: 'ignore',
+    })
+    return result.status === 0
+  }
+
+  let current = Number(pid)
+  const root = Number(rootPid)
+  for (let depth = 0; depth < 32 && current > 1; depth += 1) {
+    const result = spawnSync('ps', ['-o', 'ppid=', '-p', String(current)], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    const parent = Number((result.stdout ?? '').trim())
+    if (!parent) return false
+    if (parent === root) return true
+    current = parent
+  }
+  return false
+}
+
+function rememberProjectListeners(project) {
+  for (const port of [project.appPort, project.davPort]) {
+    for (const pid of portListenerPids(port)) {
+      if (pid !== String(process.pid) && isDescendant(pid, project.rootPid)) {
+        project.listenerPids.add(pid)
+      }
+    }
+  }
+}
+
+function startProjectPortTracking(project) {
+  const remember = () => rememberProjectListeners(project)
+  remember()
+  // The process group handles the immediate interrupt case; this slower
+  // tracker captures servers that detach before a test failure is reported.
+  project.listenerTracker = setInterval(remember, 500)
+  project.listenerTracker.unref()
+}
+
+function stopProjectPortTracking(project) {
+  if (project?.listenerTracker) clearInterval(project.listenerTracker)
+  if (project) {
+    project.listenerTracker = null
+    project.portsOwned = false
+  }
+}
+
+function killPid(pid, signal) {
+  if (process.platform === 'win32') {
+    const result = spawnSync('taskkill.exe', ['/pid', pid, '/t', '/f'], { stdio: 'ignore' })
+    if (result.error || result.status !== 0) {
+      try {
+        process.kill(Number(pid), signal)
+      } catch {
+        // The listener may have exited between discovery and cleanup.
+      }
+    }
+    return
+  }
+
+  try {
+    process.kill(Number(pid), signal)
+  } catch {
+    // The listener may have exited between discovery and cleanup.
+  }
+}
+
+function cleanupProjectPorts(project) {
+  if (!project?.portsOwned) return
+
+  if (project.listenerTracker) clearInterval(project.listenerTracker)
+  rememberProjectListeners(project)
+  for (const pid of project.listenerPids) killPid(pid, 'SIGTERM')
+  stopProjectPortTracking(project)
+}
+
+function stopAllChildren(signal) {
+  failureDetected = true
+  for (const child of children) terminateProject(child, childProjects.get(child), signal)
+}
+
+function terminateProject(child, project, signal) {
+  terminate(child, signal)
+  cleanupProjectPorts(project)
 }
 
 function prefix(project, channel, stream, chunk) {
@@ -56,10 +181,22 @@ function flush(project) {
   }
 }
 
-function runProject(project) {
+async function runProject(project) {
   const appPort = project.appPort + appPortOffset
   const davPort = project.davPort + davPortOffset
   const outputDir = `${outputRoot}/${project.name}`
+  const portsAvailable = await Promise.all([portIsFree(appPort), portIsFree(davPort)])
+  if (!portsAvailable.every(Boolean)) {
+    console.error(`[${project.name}] configured app/DAV ports are already in use`)
+    stopAllChildren('SIGTERM')
+    return { project: project.name, code: 1 }
+  }
+  if (interrupted || failureDetected) return { project: project.name, code: interrupted ? 130 : 1 }
+
+  project.appPort = appPort
+  project.davPort = davPort
+  project.portsOwned = true
+  project.listenerPids = new Set()
   const child = spawn(
     pnpm,
     [
@@ -77,6 +214,7 @@ function runProject(project) {
         // Vite keeps HMR on this server's unique app port when the host is
         // explicit, avoiding a shared default HMR port across projects.
         CALINO_DEV_HOST: 'localhost',
+        PLAYWRIGHT_PARALLEL_RUNNER: '1',
         E2E_PORT: String(appPort),
         DAV_PORT: String(davPort),
         PLAYWRIGHT_OUTPUT_DIR: outputDir,
@@ -86,6 +224,9 @@ function runProject(project) {
   )
 
   children.add(child)
+  childProjects.set(child, project)
+  project.rootPid = child.pid
+  startProjectPortTracking(project)
   child.stdout.on('data', (chunk) => prefix(project.name, 'stdout', process.stdout, chunk))
   child.stderr.on('data', (chunk) => prefix(project.name, 'stderr', process.stderr, chunk))
 
@@ -94,8 +235,18 @@ function runProject(project) {
     const finish = (result) => {
       if (settled) return
       settled = true
+
+      if (result.code !== 0 && !interrupted) {
+        // A failed browser can leave Playwright's Vite/DAV children alive.
+        // Stop the failed group and its siblings so the runner cannot hang or
+        // leak ports while waiting for the other projects.
+        stopAllChildren('SIGTERM')
+      }
+
       flush(project.name)
+      stopProjectPortTracking(project)
       children.delete(child)
+      childProjects.delete(child)
       resolve(result)
     }
 
@@ -116,7 +267,7 @@ function runProject(project) {
 for (const signal of ['SIGINT', 'SIGTERM']) {
   process.once(signal, () => {
     interrupted = true
-    for (const child of children) terminate(child, signal)
+    stopAllChildren(signal)
   })
 }
 


### PR DESCRIPTION
## Summary
- run the three Playwright browser projects concurrently with isolated app/DAV ports
- clean up runner-owned servers and preserve any existing `calino:test` image
- avoid redundant production builds and prevent dry-run/release checks from mutating or pushing release artifacts

## Verification
- `pnpm check`
- `bash -n scripts/release.sh`
- `node --check scripts/run-e2e-projects.mjs`
- `git diff --check origin/main...HEAD`

This PR does not bump the version, run the release script, create a release, or push images.