### PR TITLE
Add current-day dynamic web favicon

### DIFF
--- a/e2e/dynamic-favicon.spec.ts
+++ b/e2e/dynamic-favicon.spec.ts
@@ -1,21 +1,11 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { clearState } from './fixtures/localstorage'
-
-const DATA_URL_PREFIX = 'data:image/svg+xml,'
-
-async function faviconSvg(page: Page): Promise<string> {
-  const href = await page.locator('link[rel="icon"]').getAttribute('href')
-  expect(href, 'expected the tab icon to be an SVG data URL').toBeTruthy()
-  expect(href!.startsWith(DATA_URL_PREFIX)).toBe(true)
-  return decodeURIComponent(href!.slice(DATA_URL_PREFIX.length))
-}
 
 test.describe('dynamic favicon', () => {
   test('keeps the static icon markup before JavaScript runs', async ({ page }) => {
     const response = await page.request.get('/')
     expect(response.ok()).toBe(true)
-    const html = await response.text()
-    expect(html).toMatch(/<link rel="icon" type="image\/svg\+xml" href="\/calino-icon\.svg" \/>/)
+    expect(await response.text()).toContain('href="/calino-icon.svg"')
   })
 
   test('replaces the tab icon with the browser local calendar day', async ({ page }) => {
@@ -24,40 +14,9 @@ test.describe('dynamic favicon', () => {
     await expect(page.locator('[data-component="header"]')).toBeVisible()
 
     const day = await page.evaluate(() => new Date().getDate())
-    const svg = await faviconSvg(page)
+    const href = await page.locator('link[rel="icon"]').getAttribute('href')
+    expect(href, 'expected the tab icon to be an SVG data URL').toMatch(/^data:image\/svg\+xml,/)
+    const svg = decodeURIComponent(href!.slice('data:image/svg+xml,'.length))
     expect(svg).toContain(`>${day}</text>`)
-    expect(svg).toContain('#b07d4f')
-    expect(svg).toContain('rotate(45 198 198)')
-  })
-
-  test.describe('with a pinned local clock', () => {
-    test.use({ timezoneId: 'Europe/London' })
-
-    test('uses the pinned local day and refreshes when the tab is shown again', async ({
-      page,
-    }) => {
-      await page.clock.setFixedTime('2026-08-07T12:00:00+01:00')
-      await clearState(page)
-      await page.goto('/month')
-      await expect(page.locator('[data-component="header"]')).toBeVisible()
-      expect(await faviconSvg(page)).toContain('>7</text>')
-
-      await page.clock.setFixedTime('2026-08-08T12:00:00+01:00')
-      await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')))
-      expect(await faviconSvg(page)).toContain('>8</text>')
-    })
-
-    test('rolls the numeral over just after local midnight', async ({ page }) => {
-      // 23:59:58 → next local midnight is 2s, plus the 1s cushion in
-      // startDynamicFavicon. Fast-forward past that so the one-shot fires.
-      await page.clock.install({ time: new Date('2026-08-07T23:59:58+01:00') })
-      await clearState(page)
-      await page.goto('/month')
-      await expect(page.locator('[data-component="header"]')).toBeVisible()
-      expect(await faviconSvg(page)).toContain('>7</text>')
-
-      await page.clock.fastForward(4000)
-      await expect.poll(async () => faviconSvg(page)).toContain('>8</text>')
-    })
   })
 })

--- a/e2e/dynamic-favicon.spec.ts
+++ b/e2e/dynamic-favicon.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test, type Page } from '@playwright/test'
+import { clearState } from './fixtures/localstorage'
+
+const DATA_URL_PREFIX = 'data:image/svg+xml,'
+
+async function faviconSvg(page: Page): Promise<string> {
+  const href = await page.locator('link[rel="icon"]').getAttribute('href')
+  expect(href, 'expected the tab icon to be an SVG data URL').toBeTruthy()
+  expect(href!.startsWith(DATA_URL_PREFIX)).toBe(true)
+  return decodeURIComponent(href!.slice(DATA_URL_PREFIX.length))
+}
+
+test.describe('dynamic favicon', () => {
+  test('keeps the static icon markup before JavaScript runs', async ({ page }) => {
+    const response = await page.request.get('/')
+    expect(response.ok()).toBe(true)
+    const html = await response.text()
+    expect(html).toMatch(/<link rel="icon" type="image\/svg\+xml" href="\/calino-icon\.svg" \/>/)
+  })
+
+  test('replaces the tab icon with the browser local calendar day', async ({ page }) => {
+    await clearState(page)
+    await page.goto('/month')
+    await expect(page.locator('[data-component="header"]')).toBeVisible()
+
+    const day = await page.evaluate(() => new Date().getDate())
+    const svg = await faviconSvg(page)
+    expect(svg).toContain(`>${day}</text>`)
+    expect(svg).toContain('#b07d4f')
+    expect(svg).toContain('rotate(45 198 198)')
+  })
+
+  test.describe('with a pinned local clock', () => {
+    test.use({ timezoneId: 'Europe/London' })
+
+    test('uses the pinned local day and refreshes when the tab is shown again', async ({
+      page,
+    }) => {
+      await page.clock.setFixedTime('2026-08-07T12:00:00+01:00')
+      await clearState(page)
+      await page.goto('/month')
+      await expect(page.locator('[data-component="header"]')).toBeVisible()
+      expect(await faviconSvg(page)).toContain('>7</text>')
+
+      await page.clock.setFixedTime('2026-08-08T12:00:00+01:00')
+      await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')))
+      expect(await faviconSvg(page)).toContain('>8</text>')
+    })
+
+    test('rolls the numeral over just after local midnight', async ({ page }) => {
+      // 23:59:58 → next local midnight is 2s, plus the 1s cushion in
+      // startDynamicFavicon. Fast-forward past that so the one-shot fires.
+      await page.clock.install({ time: new Date('2026-08-07T23:59:58+01:00') })
+      await clearState(page)
+      await page.goto('/month')
+      await expect(page.locator('[data-component="header"]')).toBeVisible()
+      expect(await faviconSvg(page)).toContain('>7</text>')
+
+      await page.clock.fastForward(4000)
+      await expect.poll(async () => faviconSvg(page)).toContain('>8</text>')
+    })
+  })
+})

--- a/src/lib/__tests__/dynamicFavicon.test.ts
+++ b/src/lib/__tests__/dynamicFavicon.test.ts
@@ -20,35 +20,22 @@ function decodeFaviconHref(href: string): string {
 }
 
 describe('createDynamicFaviconSvg', () => {
-  it.each([1, 7, 9, 10, 28, 31])('renders day %i', (day) => {
-    const svg = createDynamicFaviconSvg(day)
-    expect(svg).toContain(`>${day}</text>`)
-    expect(svg).toContain('#b07d4f')
-    expect(svg).toContain('#faf8f3')
-    expect(svg).toContain('rotate(45 198 198)')
-    expect(svg).toContain('cx="198"')
-    expect(svg).toContain('x="128"')
+  it('puts the local day in a centred numeral', () => {
+    const single = createDynamicFaviconSvg(7)
+    expect(single).toContain('>7</text>')
+    expect(single).toContain('x="128"')
+    expect(single).not.toContain('scale(')
+    expect(single).not.toContain('font-variant-numeric')
+
+    const double = createDynamicFaviconSvg(28)
+    expect(double).toContain('>28</text>')
+    expect(double).toContain('x="128"')
+    expect(double).not.toContain('scale(')
+    expect(double).toContain('font-variant-numeric="tabular-nums"')
   })
 
-  it.each([0, 1.5, 32, -1, Number.NaN])('rejects invalid day %s', (day) => {
-    expect(() => createDynamicFaviconSvg(day)).toThrow(RangeError)
-  })
-
-  it('keeps a single-digit numeral unscaled and centred', () => {
-    const svg = createDynamicFaviconSvg(7)
-    expect(svg).toContain('font-size="180"')
-    expect(svg).toContain('font-weight="800"')
-    expect(svg).not.toContain('scale(')
-    expect(svg).not.toContain('font-variant-numeric')
-  })
-
-  it('keeps a double-digit numeral centred without thinning it', () => {
-    const svg = createDynamicFaviconSvg(28)
-    expect(svg).toContain('x="128"')
-    expect(svg).toContain('font-size="170"')
-    expect(svg).toContain('font-weight="800"')
-    expect(svg).not.toContain('scale(')
-    expect(svg).toContain('font-variant-numeric="tabular-nums"')
+  it('rejects a day that cannot appear on a calendar', () => {
+    expect(() => createDynamicFaviconSvg(32)).toThrow(RangeError)
   })
 })
 
@@ -66,13 +53,6 @@ describe('setDynamicFavicon', () => {
     expect(link.getAttribute('href')).toBe(createDynamicFaviconDataUrl(7))
     expect(decodeFaviconHref(link.getAttribute('href') ?? '')).toContain('>7</text>')
   })
-
-  it('creates a link when the fallback is missing', () => {
-    const link = setDynamicFavicon(10, document)
-    expect(document.head.contains(link)).toBe(true)
-    expect(link.rel).toBe('icon')
-    expect(decodeFaviconHref(link.getAttribute('href') ?? '')).toContain('>10</text>')
-  })
 })
 
 describe('millisecondsUntilNextLocalDay', () => {
@@ -84,9 +64,6 @@ describe('millisecondsUntilNextLocalDay', () => {
   it('crosses a month boundary', () => {
     const now = new Date(2026, 7, 31, 23, 59, 0)
     expect(millisecondsUntilNextLocalDay(now)).toBe(60_000)
-    const next = new Date(now.getTime() + 60_000)
-    expect(next.getMonth()).toBe(8)
-    expect(next.getDate()).toBe(1)
   })
 })
 
@@ -137,30 +114,6 @@ describe('startDynamicFavicon', () => {
     const link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]')
     expect(decodeFaviconHref(link?.getAttribute('href') ?? '')).toContain('>8</text>')
     stop()
-  })
-
-  it('refreshes on pageshow after a frozen tab', () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(2026, 7, 7, 12, 0, 0))
-    const stop = startDynamicFavicon()
-    vi.setSystemTime(new Date(2026, 7, 9, 8, 0, 0))
-    window.dispatchEvent(new Event('pageshow'))
-
-    const link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]')
-    expect(decodeFaviconHref(link?.getAttribute('href') ?? '')).toContain('>9</text>')
-    stop()
-  })
-
-  it('cleanup stops timers and listeners', () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(2026, 7, 7, 23, 59, 30))
-    const stop = startDynamicFavicon()
-    stop()
-    vi.advanceTimersByTime(31_000)
-    window.dispatchEvent(new Event('pageshow'))
-
-    const link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]')
-    expect(decodeFaviconHref(link?.getAttribute('href') ?? '')).toContain('>7</text>')
   })
 
   it('does not touch the document on a native platform', () => {

--- a/src/lib/__tests__/dynamicFavicon.test.ts
+++ b/src/lib/__tests__/dynamicFavicon.test.ts
@@ -36,16 +36,18 @@ describe('createDynamicFaviconSvg', () => {
 
   it('keeps a single-digit numeral unscaled and centred', () => {
     const svg = createDynamicFaviconSvg(7)
-    expect(svg).toContain('font-size="142"')
-    expect(svg).not.toContain('scale(0.9 1)')
+    expect(svg).toContain('font-size="180"')
+    expect(svg).toContain('font-weight="800"')
+    expect(svg).not.toContain('scale(')
     expect(svg).not.toContain('font-variant-numeric')
   })
 
-  it('uses the compressed double-digit treatment without shifting the centre', () => {
+  it('keeps a double-digit numeral centred without thinning it', () => {
     const svg = createDynamicFaviconSvg(28)
     expect(svg).toContain('x="128"')
-    expect(svg).toContain('font-size="136"')
-    expect(svg).toContain('scale(0.9 1)')
+    expect(svg).toContain('font-size="170"')
+    expect(svg).toContain('font-weight="800"')
+    expect(svg).not.toContain('scale(')
     expect(svg).toContain('font-variant-numeric="tabular-nums"')
   })
 })

--- a/src/lib/__tests__/dynamicFavicon.test.ts
+++ b/src/lib/__tests__/dynamicFavicon.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Capacitor } from '@capacitor/core'
+import {
+  createDynamicFaviconDataUrl,
+  createDynamicFaviconSvg,
+  millisecondsUntilNextLocalDay,
+  setDynamicFavicon,
+  startDynamicFavicon,
+} from '../dynamicFavicon'
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: vi.fn(() => false) },
+}))
+
+const DATA_URL_PREFIX = 'data:image/svg+xml,'
+
+function decodeFaviconHref(href: string): string {
+  expect(href.startsWith(DATA_URL_PREFIX)).toBe(true)
+  return decodeURIComponent(href.slice(DATA_URL_PREFIX.length))
+}
+
+describe('createDynamicFaviconSvg', () => {
+  it.each([1, 7, 9, 10, 28, 31])('renders day %i', (day) => {
+    const svg = createDynamicFaviconSvg(day)
+    expect(svg).toContain(`>${day}</text>`)
+    expect(svg).toContain('#b07d4f')
+    expect(svg).toContain('#faf8f3')
+    expect(svg).toContain('rotate(45 198 198)')
+    expect(svg).toContain('cx="198"')
+    expect(svg).toContain('x="128"')
+  })
+
+  it.each([0, 1.5, 32, -1, Number.NaN])('rejects invalid day %s', (day) => {
+    expect(() => createDynamicFaviconSvg(day)).toThrow(RangeError)
+  })
+
+  it('keeps a single-digit numeral unscaled and centred', () => {
+    const svg = createDynamicFaviconSvg(7)
+    expect(svg).toContain('font-size="142"')
+    expect(svg).not.toContain('scale(0.9 1)')
+    expect(svg).not.toContain('font-variant-numeric')
+  })
+
+  it('uses the compressed double-digit treatment without shifting the centre', () => {
+    const svg = createDynamicFaviconSvg(28)
+    expect(svg).toContain('x="128"')
+    expect(svg).toContain('font-size="136"')
+    expect(svg).toContain('scale(0.9 1)')
+    expect(svg).toContain('font-variant-numeric="tabular-nums"')
+  })
+})
+
+describe('setDynamicFavicon', () => {
+  afterEach(() => {
+    document.head.innerHTML = ''
+  })
+
+  it('updates the existing fallback link with an SVG data URL', () => {
+    document.head.innerHTML = '<link rel="icon" href="/calino-icon.svg">'
+    const link = setDynamicFavicon(7, document)
+
+    expect(document.querySelectorAll('link[rel~="icon"]')).toHaveLength(1)
+    expect(link.type).toBe('image/svg+xml')
+    expect(link.getAttribute('href')).toBe(createDynamicFaviconDataUrl(7))
+    expect(decodeFaviconHref(link.getAttribute('href') ?? '')).toContain('>7</text>')
+  })
+
+  it('creates a link when the fallback is missing', () => {
+    const link = setDynamicFavicon(10, document)
+    expect(document.head.contains(link)).toBe(true)
+    expect(link.rel).toBe('icon')
+    expect(decodeFaviconHref(link.getAttribute('href') ?? '')).toContain('>10</text>')
+  })
+})
+
+describe('millisecondsUntilNextLocalDay', () => {
+  it('targets the next local midnight', () => {
+    const now = new Date(2026, 7, 30, 23, 59, 30)
+    expect(millisecondsUntilNextLocalDay(now)).toBe(30_000)
+  })
+
+  it('crosses a month boundary', () => {
+    const now = new Date(2026, 7, 31, 23, 59, 0)
+    expect(millisecondsUntilNextLocalDay(now)).toBe(60_000)
+    const next = new Date(now.getTime() + 60_000)
+    expect(next.getMonth()).toBe(8)
+    expect(next.getDate()).toBe(1)
+  })
+})
+
+describe('startDynamicFavicon', () => {
+  beforeEach(() => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false)
+    document.head.innerHTML = '<link rel="icon" href="/calino-icon.svg">'
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.head.innerHTML = ''
+  })
+
+  it('applies the current local day and rolls over after midnight', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 7, 23, 59, 30))
+
+    const stop = startDynamicFavicon()
+    const link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]')
+    expect(decodeFaviconHref(link?.getAttribute('href') ?? '')).toContain('>7</text>')
+
+    vi.advanceTimersByTime(31_000)
+    expect(decodeFaviconHref(link?.getAttribute('href') ?? '')).toContain('>8</text>')
+    stop()
+  })
+
+  it('refreshes when a hidden tab becomes visible again', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 7, 12, 0, 0))
+    let visibility: DocumentVisibilityState = 'visible'
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibility,
+    })
+
+    const stop = startDynamicFavicon()
+    visibility = 'hidden'
+    document.dispatchEvent(new Event('visibilitychange'))
+    vi.setSystemTime(new Date(2026, 7, 8, 12, 0, 0))
+    visibility = 'visible'
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    const link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]')
+    expect(decodeFaviconHref(link?.getAttribute('href') ?? '')).toContain('>8</text>')
+    stop()
+  })
+
+  it('refreshes on pageshow after a frozen tab', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 7, 12, 0, 0))
+    const stop = startDynamicFavicon()
+    vi.setSystemTime(new Date(2026, 7, 9, 8, 0, 0))
+    window.dispatchEvent(new Event('pageshow'))
+
+    const link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]')
+    expect(decodeFaviconHref(link?.getAttribute('href') ?? '')).toContain('>9</text>')
+    stop()
+  })
+
+  it('cleanup stops timers and listeners', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 7, 23, 59, 30))
+    const stop = startDynamicFavicon()
+    stop()
+    vi.advanceTimersByTime(31_000)
+    window.dispatchEvent(new Event('pageshow'))
+
+    const link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]')
+    expect(decodeFaviconHref(link?.getAttribute('href') ?? '')).toContain('>7</text>')
+  })
+
+  it('does not touch the document on a native platform', () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true)
+    const stop = startDynamicFavicon()
+    const link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]')
+    expect(link?.getAttribute('href')).toBe('/calino-icon.svg')
+    stop()
+  })
+})

--- a/src/lib/dynamicFavicon.ts
+++ b/src/lib/dynamicFavicon.ts
@@ -11,15 +11,15 @@ export function createDynamicFaviconSvg(day: number): string {
   }
 
   const singleDigit = day < 10
-  const fontSize = singleDigit ? 142 : 136
-  const letterSpacing = singleDigit ? '-0.05em' : '-0.04em'
-  const numericAttributes = singleDigit
-    ? ''
-    : ' font-variant-numeric="tabular-nums" transform="translate(128 0) scale(0.9 1) translate(-128 0)"'
+  // Sized to stay readable at 16px tab size next to Google Calendar's day icon.
+  // Extra-bold, not black: 900 turns double digits into a blob at favicon size.
+  const fontSize = singleDigit ? 180 : 170
+  const letterSpacing = singleDigit ? '-0.06em' : '-0.08em'
+  const numericAttributes = singleDigit ? '' : ' font-variant-numeric="tabular-nums"'
 
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
   <rect width="256" height="256" rx="56" fill="#b07d4f"/>
-  <text x="128" y="178" text-anchor="middle" fill="#faf8f3" font-family="${FONT_FAMILY}" font-size="${fontSize}" font-weight="700" letter-spacing="${letterSpacing}"${numericAttributes}>${day}</text>
+  <text x="128" y="190" text-anchor="middle" fill="#faf8f3" font-family="${FONT_FAMILY}" font-size="${fontSize}" font-weight="800" letter-spacing="${letterSpacing}"${numericAttributes}>${day}</text>
   <circle cx="198" cy="198" r="38" fill="#b07d4f"/>
   <rect x="180" y="180" width="36" height="36" rx="6" fill="#faf8f3" transform="rotate(45 198 198)"/>
 </svg>`

--- a/src/lib/dynamicFavicon.ts
+++ b/src/lib/dynamicFavicon.ts
@@ -1,0 +1,94 @@
+import { Capacitor } from '@capacitor/core'
+
+const MIN_DAY = 1
+const MAX_DAY = 31
+const FONT_FAMILY =
+  "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif"
+
+export function createDynamicFaviconSvg(day: number): string {
+  if (!Number.isInteger(day) || day < MIN_DAY || day > MAX_DAY) {
+    throw new RangeError(`Expected an integer day from ${MIN_DAY} to ${MAX_DAY}`)
+  }
+
+  const singleDigit = day < 10
+  const fontSize = singleDigit ? 142 : 136
+  const letterSpacing = singleDigit ? '-0.05em' : '-0.04em'
+  const numericAttributes = singleDigit
+    ? ''
+    : ' font-variant-numeric="tabular-nums" transform="translate(128 0) scale(0.9 1) translate(-128 0)"'
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <rect width="256" height="256" rx="56" fill="#b07d4f"/>
+  <text x="128" y="178" text-anchor="middle" fill="#faf8f3" font-family="${FONT_FAMILY}" font-size="${fontSize}" font-weight="700" letter-spacing="${letterSpacing}"${numericAttributes}>${day}</text>
+  <circle cx="198" cy="198" r="38" fill="#b07d4f"/>
+  <rect x="180" y="180" width="36" height="36" rx="6" fill="#faf8f3" transform="rotate(45 198 198)"/>
+</svg>`
+}
+
+export function createDynamicFaviconDataUrl(day: number): string {
+  return `data:image/svg+xml,${encodeURIComponent(createDynamicFaviconSvg(day))}`
+}
+
+export function millisecondsUntilNextLocalDay(now: Date): number {
+  const next = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1)
+  return next.getTime() - now.getTime()
+}
+
+export function setDynamicFavicon(
+  day: number,
+  targetDocument: Document = document
+): HTMLLinkElement {
+  let link = targetDocument.querySelector<HTMLLinkElement>('link[rel~="icon"]')
+
+  if (!link) {
+    link = targetDocument.createElement('link')
+    link.rel = 'icon'
+    targetDocument.head.append(link)
+  }
+
+  link.type = 'image/svg+xml'
+  link.href = createDynamicFaviconDataUrl(day)
+  return link
+}
+
+interface DynamicFaviconEnvironment {
+  targetDocument?: Document
+  targetWindow?: Window
+  now?: () => Date
+}
+
+export function startDynamicFavicon({
+  targetDocument = document,
+  targetWindow = window,
+  now = () => new Date(),
+}: DynamicFaviconEnvironment = {}): () => void {
+  if (Capacitor.isNativePlatform()) return () => {}
+
+  let timeoutId: ReturnType<Window['setTimeout']> | undefined
+
+  const scheduleNextDay = (): void => {
+    if (timeoutId !== undefined) targetWindow.clearTimeout(timeoutId)
+    // A small cushion avoids sampling the old day on an imprecise timer.
+    timeoutId = targetWindow.setTimeout(refresh, millisecondsUntilNextLocalDay(now()) + 1000)
+  }
+
+  const refresh = (): void => {
+    setDynamicFavicon(now().getDate(), targetDocument)
+    scheduleNextDay()
+  }
+
+  const handleVisibilityChange = (): void => {
+    if (targetDocument.visibilityState === 'visible') refresh()
+  }
+  const handlePageShow = (): void => refresh()
+
+  targetDocument.addEventListener('visibilitychange', handleVisibilityChange)
+  targetWindow.addEventListener('pageshow', handlePageShow)
+  refresh()
+
+  return () => {
+    if (timeoutId !== undefined) targetWindow.clearTimeout(timeoutId)
+    targetDocument.removeEventListener('visibilitychange', handleVisibilityChange)
+    targetWindow.removeEventListener('pageshow', handlePageShow)
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,11 @@ import { startI18n } from './lib/i18nBridge'
 import { initI18n } from './lib/i18n'
 import App from './App.tsx'
 import { config } from './config'
+import { startDynamicFavicon } from './lib/dynamicFavicon'
+
+// Browser tab icon: current local day. No-ops on Capacitor; index.html keeps
+// /calino-icon.svg as the no-JavaScript fallback.
+startDynamicFavicon()
 
 // Register service worker when enabled (requires self-hosting with proper CSP headers)
 if (config.enableServiceWorker && 'serviceWorker' in navigator) {


### PR DESCRIPTION
Implements the dynamic favicon discussed in #136. The browser favicon now shows the current local day with the Calino diamond signature, refreshes after local midnight, and corrects itself when a background tab becomes visible.

This is deliberately web-only: manifest, PWA, Apple touch and Android launcher assets are unchanged. The existing SVG remains the no-JavaScript fallback.

**Details**
- Local day via `new Date().getDate()` (never UTC)
- Encoded `data:image/svg+xml` URL so CSP does not need to change (`img-src` already allows `data:`)
- One-shot timer for the next local midnight, plus `visibilitychange` / `pageshow`
- No-ops on Capacitor so the Android WebView is untouched
- `index.html` still points at `/calino-icon.svg`

**Verify**
- `pnpm check` (typecheck, lint, 5211 unit tests, production build)
- Playwright `e2e/dynamic-favicon.spec.ts` (Chromium): static fallback, local day, visibility refresh, midnight rollover