### PR TITLE
feat(themes): add Catppuccin light companion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Calino will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Catppuccin light** — the existing Catppuccin dark theme (Mocha) now has a
+  Latte companion under the same name, so Light/Dark/System can stay on
+  Catppuccin. The accent picker maps the same seven colours onto each flavour.
+
 ## [0.33.0] - 2026-08-30
 
 ### Added

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -24,6 +24,8 @@ Calino's appearance is fully customizable via CSS. Themes are loaded at build ti
 | Xiaohongshu Dark | dark  | Dark variant of Xiaohongshu                                      |
 | Bauhaus          | both  | Bold geometric primary colors                                    |
 | Brutalist        | both  | High-contrast black/yellow, raw edges                            |
+| Catppuccin       | light | Official Latte palette with configurable accents                 |
+| Catppuccin       | dark  | Official Mocha palette with configurable accents                 |
 | Adjustable       | both  | User-controlled colors, radius, density, shadows, and event tint |
 
 Adjustable is also available from Appearance settings as **Adjustable Light**

--- a/e2e/native-controls-theme.spec.ts
+++ b/e2e/native-controls-theme.spec.ts
@@ -80,9 +80,9 @@ test.describe('native controls follow the active theme', () => {
     await page.getByRole('button', { name: 'Appearance' }).click()
 
     await page.locator('[data-component="theme-mode-option"][data-value="dark"]').click()
-    const mochaCard = page.locator(
-      '[data-component="theme-preview-card"][data-theme-id="Catppuccin"]'
-    )
+    const mochaCard = page
+      .locator('[data-component="theme-preview-grid"][data-theme-mode="dark"]')
+      .locator('[data-component="theme-preview-card"][data-theme-id="Catppuccin"]')
     await expect(mochaCard).toBeVisible()
     await mochaCard.click()
 
@@ -145,6 +145,101 @@ test.describe('native controls follow the active theme', () => {
     await expect(page.locator('html')).toHaveCSS('background-color', 'rgb(30, 30, 46)')
     await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(30, 30, 46)')
     await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute('content', '#89b4fa')
+  })
+
+  test('Catppuccin is selectable, persists, and styles light controls', async ({ page }) => {
+    await clearState(page)
+    await page.goto('/settings')
+    await page.getByRole('button', { name: 'Appearance' }).click()
+
+    await page.locator('[data-component="theme-mode-option"][data-value="light"]').click()
+    const latteCard = page
+      .locator('[data-component="theme-preview-grid"][data-theme-mode="light"]')
+      .locator('[data-component="theme-preview-card"][data-theme-id="Catppuccin"]')
+    await expect(latteCard).toBeVisible()
+    await latteCard.click()
+
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light')
+    await expect(page.locator('html')).toHaveAttribute('data-theme-id', 'catppuccin-latte')
+    await expect(latteCard).toHaveAttribute('data-active', 'true')
+    await expect(page.locator('html')).toHaveCSS('--color-bg-primary', '#eff1f5')
+    await expect(page.locator('html')).toHaveCSS('--color-text-primary', '#4c4f69')
+    await expect(page.locator('html')).toHaveCSS('--event-rail-mix', '100%')
+    await expect(page.locator('html')).toHaveCSS('--event-marker-mix', '100%')
+    await page.getByRole('button', { name: 'Use Mauve accent' }).click()
+    await expect(page.locator('html')).toHaveCSS('--color-accent', '#8839ef')
+    await page.goto('/month')
+    await expect(
+      page.locator('[data-component="calendar-grid"] [data-today] button').first()
+    ).toHaveCSS('color', 'rgb(239, 241, 245)')
+
+    await page.goto('/tasks')
+    await page.locator('[data-component="add-task-button"]').click()
+    await page.getByPlaceholder('What needs doing?').fill('Latte controls')
+    await page.getByPlaceholder('What needs doing?').press('Enter')
+    await expect(page.locator('#priority-select')).toBeVisible()
+
+    for (const selector of [
+      '#priority-select',
+      '[data-component="event-calendar-select"]',
+      '#due-date',
+    ]) {
+      await expect(page.locator(selector)).toHaveCSS('color-scheme', 'light')
+    }
+
+    await page.reload()
+    await expect(page.locator('html')).toHaveAttribute('data-theme-id', 'catppuccin-latte')
+    await expect(page.locator('html')).toHaveCSS('--color-accent', '#8839ef')
+    await expect(page.locator('html')).toHaveCSS('--color-bg-primary', '#eff1f5')
+    await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(239, 241, 245)')
+  })
+
+  test('Catppuccin accent follows the flavour across light and dark', async ({ page }) => {
+    await clearState(page)
+    await page.goto('/settings')
+    await page.getByRole('button', { name: 'Appearance' }).click()
+
+    await page.locator('[data-component="theme-mode-option"][data-value="light"]').click()
+    await page
+      .locator('[data-component="theme-preview-grid"][data-theme-mode="light"]')
+      .locator('[data-component="theme-preview-card"][data-theme-id="Catppuccin"]')
+      .click()
+    await page.getByRole('button', { name: 'Use Mauve accent' }).click()
+    await expect(page.locator('html')).toHaveCSS('--color-accent', '#8839ef')
+
+    await page.locator('[data-component="theme-mode-option"][data-value="dark"]').click()
+    await page
+      .locator('[data-component="theme-preview-grid"][data-theme-mode="dark"]')
+      .locator('[data-component="theme-preview-card"][data-theme-id="Catppuccin"]')
+      .click()
+    await expect(page.locator('html')).toHaveAttribute('data-theme-id', 'catppuccin-mocha')
+    await expect(page.locator('html')).toHaveCSS('--color-accent', '#cba6f7')
+  })
+
+  test('Catppuccin light paints the document before React loads', async ({ page }) => {
+    await page.addInitScript(
+      ({ settingsKey }: { settingsKey: string }) => {
+        localStorage.setItem(
+          settingsKey,
+          JSON.stringify({
+            state: {
+              themeMode: 'light',
+              lightTheme: 'catppuccin-latte',
+              mochaAccent: '#cba6f7',
+            },
+            version: 1,
+          })
+        )
+      },
+      { settingsKey: STORAGE_KEYS.settings }
+    )
+    await page.route('**/src/main.tsx', (route) => route.fulfill({ body: '' }))
+
+    await page.goto('/month')
+
+    await expect(page.locator('html')).toHaveCSS('background-color', 'rgb(239, 241, 245)')
+    await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(239, 241, 245)')
+    await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute('content', '#8839ef')
   })
 
   test('task selects and date inputs use the dark browser color scheme', async ({ page }) => {

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#faf9f7" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'sha256-Qh5qqVHNcx0NmWPlYwpmDet5mMrPYpSQ6hcLzJTT3ZM=' 'sha256-am6yAzlcRW7qKd6V78oFkolYjWok3WEYJJY8fqkSPgA='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https:; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com"
+      content="default-src 'self'; script-src 'self' 'sha256-Qh5qqVHNcx0NmWPlYwpmDet5mMrPYpSQ6hcLzJTT3ZM=' 'sha256-AQQMVAHv1tQqIVb/aeGQWZo8IWdCg5J5kzrOTtjqgCY='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https:; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com"
     />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -92,13 +92,21 @@
           var mode = settings.themeMode || 'auto';
           var isDark = mode === 'dark' || (mode === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);
           var isMocha = isDark && settings.darkTheme === 'catppuccin-mocha';
-          var mochaAccent = settings.mochaAccent || '#89b4fa';
-          var background = isMocha ? '#1e1e2e' : (isDark ? '#1a1816' : '#faf8f3');
+          var isLatte = !isDark && settings.lightTheme === 'catppuccin-latte';
+          // Must match src/lib/themes/catppuccinAccents.ts
+          var mochaAccents = ['#89b4fa','#b4befe','#cba6f7','#f5c2e7','#94e2d5','#a6e3a1','#fab387'];
+          var latteAccents = ['#1e66f5','#7287fd','#8839ef','#ea76cb','#179299','#40a02b','#fe640b'];
+          var storedAccent = settings.mochaAccent || '#89b4fa';
+          var accentIndex = mochaAccents.indexOf(storedAccent);
+          if (accentIndex < 0) accentIndex = latteAccents.indexOf(storedAccent);
+          if (accentIndex < 0) accentIndex = 0;
+          var accent = (isLatte ? latteAccents : mochaAccents)[accentIndex];
+          var background = isMocha ? '#1e1e2e' : (isLatte ? '#eff1f5' : (isDark ? '#1a1816' : '#faf8f3'));
           document.documentElement.style.background = background;
           document.body.style.background = background;
-          if (isMocha) {
+          if (isMocha || isLatte) {
             var themeColor = document.querySelector('meta[name="theme-color"]');
-            if (themeColor) themeColor.setAttribute('content', mochaAccent);
+            if (themeColor) themeColor.setAttribute('content', accent);
           }
           document.body.style.transition = 'background 0.3s ease';
         } catch(e) {}

--- a/public/themes/catppuccin-latte.css
+++ b/public/themes/catppuccin-latte.css
@@ -1,0 +1,126 @@
+/* Theme: Catppuccin | light */
+
+/* Official Catppuccin Latte palette: https://catppuccin.com/palette
+   Token roles follow catppuccin-mocha.css. Overlay 0 is 2.3:1 on Latte paper,
+   so muted text uses Subtext 0 (style guide: legibility first). Scrim/shadow
+   inks use Text — Latte Crust is cream, not a dimming colour. */
+:root,
+[data-theme='light'] {
+  /* Backgrounds and surfaces */
+  --canvas: #eff1f5;
+  --panel: #e6e9ef;
+  --side: #dce0e8;
+  --color-bg: var(--canvas);
+  --color-bg-primary: var(--canvas);
+  --color-bg-secondary: var(--panel);
+  --color-bg-secondary-rgb: 230, 233, 239;
+  --color-bg-tertiary: #ccd0da;
+  --color-bg-hover: #ccd0da;
+  --color-bg-input: #ccd0da;
+  --color-surface: var(--panel);
+  --color-surface-raised: #ccd0da;
+  --color-surface-glass: rgba(230, 233, 239, 0.88);
+  --color-surface-hover: #bcc0cc;
+  --color-surface-elevated: #ccd0da;
+
+  /* Semantic design tokens */
+  --background: var(--color-bg-primary);
+  --background-subtle: var(--color-bg-tertiary);
+  --surface: var(--color-surface);
+  --surface-hover: var(--color-surface-hover);
+  --surface-elevated: var(--color-surface-elevated);
+  --border: var(--color-border);
+  --text: var(--color-text-primary);
+  --text-muted: var(--color-text-muted);
+  --primary: var(--color-primary);
+  --primary-hover: var(--color-primary-hover);
+  --success: var(--color-success);
+  --warning: var(--color-warning);
+  --danger: var(--color-danger);
+  --info: var(--color-info);
+
+  /* Text */
+  --ink: #4c4f69;
+  --ink-2: #5c5f77;
+  --ink-3: #6c6f85;
+  --color-text: var(--ink);
+  --color-text-primary: var(--ink);
+  --color-text-secondary: var(--ink-2);
+  --color-text-muted: var(--ink-3);
+  --color-text-tertiary: var(--ink-3);
+
+  /* Borders */
+  --line: #bcc0cc;
+  --line-2: #ccd0da;
+  --color-border: var(--line);
+  --color-border-light: var(--line-2);
+  --color-border-subtle: var(--line-2);
+  --color-border-visible: var(--line);
+  --color-border-glass: rgba(76, 79, 105, 0.12);
+
+  /* Primary and semantic states */
+  --accent: var(--accent-custom, #1e66f5);
+  --accent-contrast: #eff1f5;
+  --accent-soft: color-mix(in srgb, var(--accent) 16%, transparent);
+  --color-accent: var(--accent);
+  --color-accent-hover: color-mix(in srgb, var(--accent) 72%, #4c4f69);
+  --color-accent-light: var(--accent-soft);
+  --color-primary: var(--accent);
+  --color-primary-hover: color-mix(in srgb, var(--accent) 72%, #4c4f69);
+  --color-primary-light: var(--accent-soft);
+  --color-success: #40a02b;
+  --color-success-light: rgba(64, 160, 43, 0.16);
+  --color-warning: #df8e1d;
+  --color-error: #d20f39;
+  --color-error-muted: #e64553;
+  --color-danger: #d20f39;
+  --color-danger-bg: rgba(210, 15, 57, 0.16);
+  --color-info: #04a5e5;
+
+  /* Interaction, overlay, and native controls */
+  --hover-bg: color-mix(in srgb, var(--accent) 12%, transparent);
+  --selected-bg: color-mix(in srgb, var(--accent) 20%, var(--canvas));
+  --focus-ring: color-mix(in srgb, var(--accent) 35%, transparent);
+  --chip-bg: color-mix(in srgb, var(--accent) 16%, transparent);
+  --tag-bg: color-mix(in srgb, var(--accent) 10%, transparent);
+  --tag-border: color-mix(in srgb, var(--accent) 45%, transparent);
+  --surface-bg: rgba(76, 79, 105, 0.06);
+  --surface-bg-strong: rgba(76, 79, 105, 0.1);
+  --error-bg: rgba(210, 15, 57, 0.12);
+  --error-bg-strong: rgba(210, 15, 57, 0.2);
+  --error-border: rgba(210, 15, 57, 0.45);
+  --color-overlay: rgba(76, 79, 105, 0.45);
+  --color-focus: var(--accent);
+  --color-current-time: #d20f39;
+  --day-cell-today-bg: color-mix(in srgb, var(--accent) 14%, var(--canvas));
+  --day-cell-hover-bg: color-mix(in srgb, var(--accent) 10%, var(--canvas));
+  --day-number-hover-bg: color-mix(in srgb, var(--accent) 18%, var(--canvas));
+  --day-column-today-bg: color-mix(in srgb, var(--accent) 6%, var(--canvas));
+
+  /* Elevated UI */
+  --modal-bg: #e6e9ef;
+  --popover-bg: #ccd0da;
+  --modal-scrim: var(--color-overlay);
+  --modal-blur: blur(4px);
+  --modal-border: #bcc0cc;
+  --modal-card-border: 1px solid #bcc0cc;
+  --popover-border: #bcc0cc;
+  --modal-shadow: 0 20px 60px rgba(76, 79, 105, 0.2), 0 2px 6px rgba(76, 79, 105, 0.12);
+
+  /* Supporting component tokens */
+  --ink-raw: 76, 79, 105;
+  --event-bg-mix: 24%;
+  --event-bg-mix-hover: 30%;
+  --event-rail-mix: 100%;
+  --event-marker-mix: 100%;
+  --color-scrollbar: #bcc0cc;
+  --color-scrollbar-hover: #acb0be;
+  --shadow-event: 0 1px 2px rgba(76, 79, 105, 0.12);
+  --shadow-event-hover: 0 4px 12px rgba(76, 79, 105, 0.18);
+  --shadow-card: 0 2px 8px rgba(76, 79, 105, 0.12), 0 8px 20px rgba(76, 79, 105, 0.08);
+  --shadow-sidebar: none;
+  --shadow-topbar: none;
+  --shadow-today: inset 0 0 0 1.5px color-mix(in srgb, var(--accent) 68%, transparent);
+  --shadow-glass: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  --shadow-inset: inset 0 1px 2px rgba(76, 79, 105, 0.12);
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -10,7 +10,13 @@ import {
 import { Capacitor } from '@capacitor/core'
 import { StatusBar, Style } from '@capacitor/status-bar'
 import { useSettingsStore } from '@/store/settingsStore'
-import { loadThemes, getThemeCSS, type ThemeInfo } from '@/lib/themes'
+import {
+  loadThemes,
+  getThemeCSS,
+  catppuccinFlavorForThemeId,
+  resolveCatppuccinAccent,
+  type ThemeInfo,
+} from '@/lib/themes'
 import { ADJUSTABLE_FONT_STACKS } from '@/lib/themes/adjustableFonts'
 import { ThemeContext } from './ThemeContext'
 
@@ -155,8 +161,12 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
     document.documentElement.setAttribute('data-theme', effectiveMode)
     document.documentElement.setAttribute('data-theme-mode', themeMode)
-    if (currentThemeId === 'catppuccin-mocha') {
-      document.documentElement.style.setProperty('--accent-custom', mochaAccent)
+    const catppuccinFlavor = catppuccinFlavorForThemeId(currentThemeId)
+    if (catppuccinFlavor) {
+      document.documentElement.style.setProperty(
+        '--accent-custom',
+        resolveCatppuccinAccent(mochaAccent, catppuccinFlavor)
+      )
     } else {
       document.documentElement.style.removeProperty('--accent-custom')
     }

--- a/src/features/settings/components/ThemeSettings.tsx
+++ b/src/features/settings/components/ThemeSettings.tsx
@@ -7,20 +7,15 @@ import {
   DEFAULT_ADJUSTABLE_THEME,
 } from '@/store/settingsStore'
 import { useTheme } from '@/components/ThemeContext'
-import { getThemePreviewCSS } from '@/lib/themes'
+import {
+  getThemePreviewCSS,
+  CATPPUCCIN_ACCENTS,
+  catppuccinPickerFlavor,
+  resolveCatppuccinAccent,
+} from '@/lib/themes'
 import type { AdjustableThemeProfile, AdjustableThemeSettings, ThemeMode, EventTint } from '@/types'
 import styles from './Settings.module.css'
 import { AdjustableThemeControls } from './AdjustableThemeControls'
-
-const MOCHA_ACCENTS = [
-  { labelKey: 'theme.mochaAccent.blue', value: '#89b4fa' },
-  { labelKey: 'theme.mochaAccent.lavender', value: '#b4befe' },
-  { labelKey: 'theme.mochaAccent.mauve', value: '#cba6f7' },
-  { labelKey: 'theme.mochaAccent.pink', value: '#f5c2e7' },
-  { labelKey: 'theme.mochaAccent.teal', value: '#94e2d5' },
-  { labelKey: 'theme.mochaAccent.green', value: '#a6e3a1' },
-  { labelKey: 'theme.mochaAccent.peach', value: '#fab387' },
-]
 
 function MiniCalendarPreview({
   themeId,
@@ -226,6 +221,21 @@ export function ThemeSettings(): JSX.Element {
   const darkThemes = loadedThemes
     .filter((t) => t.isDark)
     .sort((a, b) => adjustableLast(a) - adjustableLast(b))
+  const currentThemeId = effectiveMode === 'dark' ? darkTheme : lightTheme
+  const catppuccinFlavor = catppuccinPickerFlavor({
+    currentThemeId,
+    lightTheme,
+    darkTheme,
+  })
+  const catppuccinAccents = catppuccinFlavor
+    ? CATPPUCCIN_ACCENTS.map((accent) => ({
+        labelKey: accent.labelKey,
+        value: accent[catppuccinFlavor],
+      }))
+    : []
+  const activeCatppuccinAccent = catppuccinFlavor
+    ? resolveCatppuccinAccent(mochaAccent, catppuccinFlavor)
+    : ''
 
   return (
     <section
@@ -356,7 +366,7 @@ export function ThemeSettings(): JSX.Element {
             />
           ))}
         </div>
-        {darkTheme === 'catppuccin-mocha' && (
+        {catppuccinFlavor && (
           <div className={styles.row} data-component="setting-row" data-setting="mocha-accent">
             <div className={styles.rowInfo}>
               <div className={styles.rowLabel}>{t('theme.mochaAccent.label')}</div>
@@ -367,14 +377,14 @@ export function ThemeSettings(): JSX.Element {
               role="group"
               aria-label={t('theme.mochaAccent.ariaLabel')}
             >
-              {MOCHA_ACCENTS.map((accent) => (
+              {catppuccinAccents.map((accent) => (
                 <button
-                  key={accent.value}
-                  className={`${styles.mochaAccentOption} ${mochaAccent === accent.value ? styles.mochaAccentOptionActive : ''}`}
+                  key={accent.labelKey}
+                  className={`${styles.mochaAccentOption} ${activeCatppuccinAccent === accent.value ? styles.mochaAccentOptionActive : ''}`}
                   style={{ '--mocha-accent': accent.value } as CSSProperties}
                   onClick={() => updateSettings({ mochaAccent: accent.value })}
                   aria-label={t('theme.mochaAccent.useAccent', { name: t(accent.labelKey) })}
-                  aria-pressed={mochaAccent === accent.value}
+                  aria-pressed={activeCatppuccinAccent === accent.value}
                   title={t(accent.labelKey)}
                   type="button"
                 />
@@ -454,7 +464,10 @@ export function ThemeSettings(): JSX.Element {
             </label>
           </div>
         </div>
-        <div className={`${styles.row} ${styles.rowDisabled}`} title={t('theme.fontSize.notAvailable')}>
+        <div
+          className={`${styles.row} ${styles.rowDisabled}`}
+          title={t('theme.fontSize.notAvailable')}
+        >
           <div className={styles.rowInfo}>
             <div className={styles.rowLabel}>{t('theme.fontSize.label')}</div>
             <div className={styles.rowDesc}>{t('theme.fontSize.desc')}</div>

--- a/src/lib/themes/__tests__/catppuccinAccents.test.ts
+++ b/src/lib/themes/__tests__/catppuccinAccents.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CATPPUCCIN_ACCENTS,
+  CATPPUCCIN_LATTE_ID,
+  CATPPUCCIN_MOCHA_ID,
+  catppuccinFlavorForThemeId,
+  catppuccinPickerFlavor,
+  resolveCatppuccinAccent,
+} from '../catppuccinAccents'
+
+describe('catppuccin accents', () => {
+  it('maps a stored mocha hex onto Latte of the same name', () => {
+    expect(resolveCatppuccinAccent('#cba6f7', 'latte')).toBe('#8839ef')
+  })
+
+  it('maps a stored latte hex onto Mocha of the same name', () => {
+    expect(resolveCatppuccinAccent('#8839ef', 'mocha')).toBe('#cba6f7')
+  })
+
+  it('keeps the default mocha blue when the flavour is mocha', () => {
+    expect(resolveCatppuccinAccent('#89b4fa', 'mocha')).toBe('#89b4fa')
+  })
+
+  it('translates the default mocha blue onto Latte blue', () => {
+    expect(resolveCatppuccinAccent('#89b4fa', 'latte')).toBe('#1e66f5')
+  })
+
+  it('falls back to blue when the stored hex is unknown', () => {
+    expect(resolveCatppuccinAccent('#ff00ff', 'latte')).toBe('#1e66f5')
+    expect(resolveCatppuccinAccent('#ff00ff', 'mocha')).toBe('#89b4fa')
+  })
+
+  it('covers the seven picker accents in both flavours', () => {
+    expect(CATPPUCCIN_ACCENTS).toHaveLength(7)
+    for (const accent of CATPPUCCIN_ACCENTS) {
+      expect(resolveCatppuccinAccent(accent.mocha, 'latte')).toBe(accent.latte)
+      expect(resolveCatppuccinAccent(accent.latte, 'mocha')).toBe(accent.mocha)
+    }
+  })
+
+  it('recognises both theme ids', () => {
+    expect(catppuccinFlavorForThemeId(CATPPUCCIN_MOCHA_ID)).toBe('mocha')
+    expect(catppuccinFlavorForThemeId(CATPPUCCIN_LATTE_ID)).toBe('latte')
+    expect(catppuccinFlavorForThemeId('mist')).toBeNull()
+  })
+
+  it('shows the picker for a Catppuccin slot even when the other mode is default', () => {
+    expect(
+      catppuccinPickerFlavor({
+        currentThemeId: 'built-in',
+        lightTheme: CATPPUCCIN_LATTE_ID,
+        darkTheme: 'built-in-dark',
+      })
+    ).toBe('latte')
+    expect(
+      catppuccinPickerFlavor({
+        currentThemeId: 'built-in-dark',
+        lightTheme: 'built-in',
+        darkTheme: CATPPUCCIN_MOCHA_ID,
+      })
+    ).toBe('mocha')
+  })
+})

--- a/src/lib/themes/catppuccinAccents.ts
+++ b/src/lib/themes/catppuccinAccents.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared Catppuccin accent names.
+ *
+ * Mocha and Latte use the same seven accents; only the hex changes with the
+ * flavour. Settings still store `mochaAccent` as a hex (existing mocha
+ * installs), and the resolver maps that hex to the active flavour.
+ *
+ * The inline pre-React paint in index.html duplicates these lists — keep them
+ * in lockstep.
+ */
+
+export const CATPPUCCIN_MOCHA_ID = 'catppuccin-mocha'
+export const CATPPUCCIN_LATTE_ID = 'catppuccin-latte'
+
+export type CatppuccinFlavor = 'mocha' | 'latte'
+
+export const CATPPUCCIN_ACCENTS = [
+  { labelKey: 'theme.mochaAccent.blue', mocha: '#89b4fa', latte: '#1e66f5' },
+  { labelKey: 'theme.mochaAccent.lavender', mocha: '#b4befe', latte: '#7287fd' },
+  { labelKey: 'theme.mochaAccent.mauve', mocha: '#cba6f7', latte: '#8839ef' },
+  { labelKey: 'theme.mochaAccent.pink', mocha: '#f5c2e7', latte: '#ea76cb' },
+  { labelKey: 'theme.mochaAccent.teal', mocha: '#94e2d5', latte: '#179299' },
+  { labelKey: 'theme.mochaAccent.green', mocha: '#a6e3a1', latte: '#40a02b' },
+  { labelKey: 'theme.mochaAccent.peach', mocha: '#fab387', latte: '#fe640b' },
+] as const
+
+const DEFAULT_INDEX = 0
+
+export function catppuccinFlavorForThemeId(themeId: string): CatppuccinFlavor | null {
+  if (themeId === CATPPUCCIN_MOCHA_ID) return 'mocha'
+  if (themeId === CATPPUCCIN_LATTE_ID) return 'latte'
+  return null
+}
+
+function accentIndex(storedHex: string): number {
+  const i = CATPPUCCIN_ACCENTS.findIndex(
+    (accent) => accent.mocha === storedHex || accent.latte === storedHex
+  )
+  return i < 0 ? DEFAULT_INDEX : i
+}
+
+export function resolveCatppuccinAccent(storedHex: string, flavor: CatppuccinFlavor): string {
+  return CATPPUCCIN_ACCENTS[accentIndex(storedHex)][flavor]
+}
+
+export function catppuccinPickerFlavor(args: {
+  currentThemeId: string
+  lightTheme: string
+  darkTheme: string
+}): CatppuccinFlavor | null {
+  return (
+    catppuccinFlavorForThemeId(args.currentThemeId) ??
+    (args.lightTheme === CATPPUCCIN_LATTE_ID
+      ? 'latte'
+      : args.darkTheme === CATPPUCCIN_MOCHA_ID
+        ? 'mocha'
+        : null)
+  )
+}

--- a/src/lib/themes/index.ts
+++ b/src/lib/themes/index.ts
@@ -1,2 +1,3 @@
 export * from './types'
 export * from './loader'
+export * from './catppuccinAccents'


### PR DESCRIPTION
Adds a Catppuccin light theme (official Latte) as a companion to the existing Mocha dark theme. Both appear as **Catppuccin** in Appearance, so Light/Dark/System can stay on the same family.

The accent picker works on either flavour. `mochaAccent` is still stored as a hex, so existing mocha installs keep their choice; the same colour name is mapped onto Latte (and back).

**Details**

- Same token roles as mocha, official Latte hexes
- Muted text uses Subtext 0 (Overlay 0 is 2.3:1 on Latte paper)
- Scrim/shadows use Text — Latte Crust is cream, not a dimming colour
- Pre-React paint covers Latte and translates a stored mocha accent before first paint

**Verify**

- `pnpm typecheck`
- Playwright `e2e/native-controls-theme.spec.ts` (Chromium): mocha dark, Latte light, accent across flavours, both pre-React paints