### PR TITLE
test: update ThemeProvider theme mock

### DIFF
--- a/src/components/__tests__/ThemeProvider.bugs.test.tsx
+++ b/src/components/__tests__/ThemeProvider.bugs.test.tsx
@@ -29,6 +29,8 @@ vi.mock('@/store/settingsStore', () => {
 vi.mock('@/lib/themes', () => ({
   loadThemes: vi.fn().mockResolvedValue([]),
   getThemeCSS: vi.fn().mockReturnValue(''),
+  catppuccinFlavorForThemeId: vi.fn().mockReturnValue(null),
+  resolveCatppuccinAccent: vi.fn().mockReturnValue('#89b4fa'),
 }))
 
 vi.mock('../ThemeContext', () => ({


### PR DESCRIPTION
Add the new Catppuccin helper exports to the ThemeProvider test mock so the Vitest suite covers the merged theme changes.