### PR TITLE
fix: save reminder-only event edits

### DIFF
--- a/src/features/calendar/__tests__/EventModal.test.tsx
+++ b/src/features/calendar/__tests__/EventModal.test.tsx
@@ -766,6 +766,33 @@ describe('EventModal', () => {
     })
   })
 
+  it('saves an edit that changes only reminders (issue #142)', () => {
+    const store = useCalendarStore.getState()
+    store.addEvent({
+      id: 'reminder-event',
+      calendarId: 'default',
+      title: 'Reminder Event',
+      start: '2024-03-15T10:00:00',
+      end: '2024-03-15T11:00:00',
+      isAllDay: false,
+      reminders: [{ id: 'existing-reminder', minutesBefore: 15, method: 'popup' }],
+    })
+    store.openModal(undefined, undefined, 'reminder-event')
+    render(<EventModal />)
+
+    fireEvent.click(screen.getByRole('button', { name: /show more options/i }))
+    fireEvent.click(screen.getByRole('button', { name: /add reminder/i }))
+    fireEvent.click(screen.getByRole('option', { name: /30 minutes before/i }))
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(useCalendarStore.getState().events.find((e) => e.id === 'reminder-event')?.reminders).toEqual(
+      expect.arrayContaining([
+        { id: 'existing-reminder', minutesBefore: 15, method: 'popup' },
+        expect.objectContaining({ minutesBefore: 30, method: 'popup' }),
+      ])
+    )
+  })
+
   describe('date field changes preserve start<=end (issue #44)', () => {
     it('shifts the end date along with the start date for an overnight event, keeping the range valid', () => {
       const store = useCalendarStore.getState()

--- a/src/features/calendar/components/EventModal.tsx
+++ b/src/features/calendar/components/EventModal.tsx
@@ -802,6 +802,8 @@ export function EventModal(): JSX.Element | null {
     const attachmentsChanged = JSON.stringify(attachments) !== JSON.stringify(existingAttachments)
     const attendeesChanged =
       JSON.stringify(attendees) !== JSON.stringify(existingEventForMode.attendees || [])
+    const remindersChanged =
+      JSON.stringify(reminders) !== JSON.stringify(existingEventForMode.reminders || [])
 
     // R2.7 — Recurrence participates in BOTH branches now that tasks can
     // recur. Leaving it out of the task branch made a recurrence-only edit
@@ -844,7 +846,8 @@ export function EventModal(): JSX.Element | null {
           JSON.stringify(existingEventForMode.categories || []) ||
         JSON.stringify(relatedTo) !== JSON.stringify(existingEventForMode.relatedTo || []) ||
         attendeesChanged ||
-        attachmentsChanged
+        attachmentsChanged ||
+        remindersChanged
       )
     }
 
@@ -873,7 +876,8 @@ export function EventModal(): JSX.Element | null {
         JSON.stringify(existingEventForMode.categories || []) ||
       JSON.stringify(relatedTo) !== JSON.stringify(existingEventForMode.relatedTo || []) ||
       attendeesChanged ||
-      attachmentsChanged
+      attachmentsChanged ||
+      remindersChanged
     )
   }, [
     existingEventForMode,
@@ -908,6 +912,7 @@ export function EventModal(): JSX.Element | null {
     relatedTo,
     attendees,
     attachments,
+    reminders,
   ])
 
   const candidateEvents = useMemo(() => {


### PR DESCRIPTION
Fixes #142. Include reminder changes in EventModal dirty-state detection and add a regression test covering an edit that changes only reminders.