### PR TITLE
fix(caldav): derive STATUS/PERCENT-complete from completed

### DIFF
--- a/src/features/caldav/adapter/icalTypeMapping.ts
+++ b/src/features/caldav/adapter/icalTypeMapping.ts
@@ -1651,21 +1651,33 @@ export function calendarEventToIcalVtodo(
     vtodo.removeAllProperties('priority')
   }
 
-  if (task.percentComplete !== undefined) {
-    vtodo.updatePropertyWithValue('percent-complete', task.percentComplete)
+  // A sync merge can leave taskStatus/percentComplete contradicting the
+  // authoritative `completed` boolean: mark-complete keeps taskStatus=NEEDS-ACTION
+  // and percent=0, while un-complete keeps taskStatus=COMPLETED / percent=100.
+  // Trusting those stale fields made the written .ics re-serialize the wrong
+  // state, so a toggled task reverted on reload (completed = percentComplete >= 100).
+  // Derive BOTH STATUS and PERCENT-COMPLETE from a single serializeStatus based
+  // on `completed`; only a genuine IN-PROCESS / CANCELLED status is preserved.
+  const serializeStatus = task.completed
+    ? 'COMPLETED'
+    : task.taskStatus === 'IN-PROCESS' || task.taskStatus === 'CANCELLED'
+      ? task.taskStatus
+      : 'NEEDS-ACTION'
+
+  if (serializeStatus === 'COMPLETED') {
+    vtodo.updatePropertyWithValue('percent-complete', 100)
+  } else if (serializeStatus === 'IN-PROCESS' && task.percentComplete !== undefined) {
+    // keep a real in-progress percentage, but always < 100 (100 = done)
+    vtodo.updatePropertyWithValue(
+      'percent-complete',
+      Math.max(0, Math.min(99, task.percentComplete))
+    )
   } else {
+    // NEEDS-ACTION / CANCELLED — drop the stale percent so re-parse stays <100
     vtodo.removeAllProperties('percent-complete')
   }
 
-  if (task.taskStatus) {
-    // R2.5 — Serialize the full status union (NEEDS-ACTION / IN-PROCESS
-    // / COMPLETED / CANCELLED), not just COMPLETED / NEEDS-ACTION.
-    vtodo.updatePropertyWithValue('status', task.taskStatus)
-  } else if (task.completed) {
-    vtodo.updatePropertyWithValue('status', 'COMPLETED')
-  } else {
-    vtodo.updatePropertyWithValue('status', 'NEEDS-ACTION')
-  }
+  vtodo.updatePropertyWithValue('status', serializeStatus)
 
   if (task.completed) {
     // R2.5 — Preserve the original COMPLETED timestamp on re-serialize


### PR DESCRIPTION
## Problem

Toggling a task's completion in Calino writes an **inconsistent** `.ics`, so the
state **reverts on the next refresh**:

- **Mark complete** → the stored resource ends up `STATUS:NEEDS-ACTION` (with a
  `COMPLETED:` timestamp and `PERCENT-COMPLETE:100`), so a reload shows the task
  as *uncompleted* again.
- **Un-complete** → `STATUS:NEEDS-ACTION` is written but **`PERCENT-COMPLETE:100`
  is kept**, which the reader maps back to *completed* (`completed = percentComplete >= 100`),
  so a reload shows the task as *completed* again.

## Reproduction

Reproduced from a **clean import on a single client device** (fresh IndexedDB,
no multi-client / ETag race involved) — the fault is in serialization, not in
CalDAV sync.

## Root cause

A task carries several representations of "done": the boolean `completed` (the
authoritative value the toggle mutates) plus the serialized `STATUS`,
`PERCENT-COMPLETE` and `COMPLETED`. A sync merge can leave them desynchronized in
**either** direction:

- mark-complete → `completed = true` but `taskStatus = 'NEEDS-ACTION'`, `percent = 0`
- un-complete → `completed = false` but `taskStatus = 'COMPLETED'`, `percent = 100`

`calendarEventToIcalVtodo` wrote `STATUS` from `task.taskStatus` and
`PERCENT-COMPLETE` from `task.percentComplete`, trusting the possibly-stale
fields instead of the authoritative `completed`, so the wrong state got pushed to
the server.

## Fix

Derive **both** `STATUS` and `PERCENT-COMPLETE` from a single `serializeStatus`
computed from `completed` (the toggled, authoritative state). Only a genuine
`IN-PROCESS` / `CANCELLED` status is preserved verbatim; any other non-completed
task serializes `NEEDS-ACTION` with the stale percent dropped. The written
resource is therefore always self-consistent and no longer reverts on reload, and
previously-corroded tasks self-heal on their next write.

## Notes

- `COMPLETED` is still dropped on un-complete (as before).
- An `IN-PROCESS` percent is clamped to `< 100` because `>= 100` is treated as done.