### PR TITLE
fix(modal): let Enter in the title submit the event form

### DIFF
--- a/e2e/event-modal-enter-submit.spec.ts
+++ b/e2e/event-modal-enter-submit.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Enter in the event/task title submits the form.
+ *
+ * The title input lives in the modal header, above the <form>, so it used to
+ * be a stray control: Enter in it did nothing and the only way to save was
+ * to click Create. It is now tied to the form by id (issue #150).
+ */
+import { test, expect } from '@playwright/test'
+import { clearState } from './fixtures/localstorage'
+
+test.describe('event modal — Enter in the title submits', () => {
+  test.use({ viewport: { width: 1280, height: 800 } })
+
+  test.beforeEach(async ({ page }) => {
+    await clearState(page)
+  })
+
+  test('creates an event from the title field alone', async ({ page }) => {
+    await page.goto('/month')
+    await expect(page.locator('[data-component="header"]')).toBeVisible()
+
+    await page.keyboard.press('c')
+    const modal = page.locator('[data-component="modal-card"]')
+    await expect(modal).toBeVisible()
+
+    const title = modal.locator('[data-component="event-title-input"]')
+    await expect(title).toBeFocused()
+    await title.fill('Enter creates me')
+    await title.press('Enter')
+
+    await expect(modal).not.toBeVisible()
+    await expect(
+      page.locator('[data-component="calendar-grid"]').getByText('Enter creates me')
+    ).toBeVisible()
+  })
+
+  test('creates a task from the composer with two Enters', async ({ page }) => {
+    await page.goto('/tasks')
+    await page.locator('[data-component="add-task-button"]').click()
+
+    const composer = page.getByPlaceholder('What needs doing?')
+    await composer.fill('Enter creates a task')
+    await composer.press('Enter')
+
+    const modal = page.locator('[data-component="modal-card"]')
+    await expect(modal).toBeVisible()
+    const title = modal.locator('[data-component="event-title-input"]')
+    await expect(title).toHaveValue('Enter creates a task')
+    await expect(title).toBeFocused()
+    await title.press('Enter')
+
+    await expect(modal).not.toBeVisible()
+    await expect(page.locator('main').getByText('Enter creates a task')).toBeVisible()
+  })
+})

--- a/src/features/calendar/components/EventModal.tsx
+++ b/src/features/calendar/components/EventModal.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'react'
-import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
+import { useState, useMemo, useEffect, useRef, useCallback, useId } from 'react'
 import { motion } from 'framer-motion'
 import { format, parseISO } from 'date-fns'
 import { useTranslation } from 'react-i18next'
@@ -307,6 +307,10 @@ export function EventModal(): JSX.Element | null {
   // the form below would keep the last event's values, including its reminders.
   const wasModalOpen = useRef(false)
   const titleInputRef = useRef<HTMLInputElement>(null)
+  // The title input sits in the modal header, above the <form>, so it has to
+  // be tied to the form by id. Without that it is not a form control at all:
+  // Enter in it submits nothing, and its `required` never runs.
+  const formId = useId()
 
   useFocusTrap(dialogRef, isModalOpen && !isClosing)
 
@@ -1649,6 +1653,7 @@ export function EventModal(): JSX.Element | null {
                   onKeyDown={handleTitleKeyDown}
                   className={styles.modalTitle}
                   data-component="event-title-input"
+                  form={formId}
                   required
                   onInvalid={(e) => {
                     e.preventDefault()
@@ -1704,6 +1709,7 @@ export function EventModal(): JSX.Element | null {
           <hr className={styles.modalDivider} />
           <form
             key={`${selectedEventId}-${selectedDate}-${selectedEventType}`}
+            id={formId}
             onClick={(e) => {
               // Close suggestions when clicking outside the suggestions dropdown
               if (!(e.target as HTMLElement).closest(`.${styles.titleSuggestions}`)) {


### PR DESCRIPTION
Fixes #150.

The title input is in the modal header, which sits above the `<form>`, so it wasn't a control of that form and Enter in it went nowhere. This gives the form an `id` (via `useId`) and points the input at it with `form=`. Implicit submission then goes through the existing Create/Save button, so all of its `disabled` conditions still apply: Enter with an empty title, a bad time range or a read-only calendar does nothing, same as clicking would. Every other button inside the form is already `type="button"`, so Create stays the default button.

Side effect worth knowing: the `required` on the title input now actually participates in validation, which it never did before.

Plain Enter with the NLP chip showing submits the title as typed; Tab / Shift+Enter still apply the parse, as before.

New spec `e2e/event-modal-enter-submit.spec.ts` covers an event via `c` and a task via the composer (two Enters). It fails on main and passes here. `pnpm typecheck`, eslint on the touched files, the EventModal unit tests and the neighbouring modal specs (event-modal-desktop, accessibility, nlp-command-palette, categories) pass in Chromium.
