### PR TITLE
fix(header): make the wordmark the home button, show the title is one

### DIFF
--- a/e2e/header-home.spec.ts
+++ b/e2e/header-home.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * The "Calino" wordmark in the header is the home control: it returns to
+ * month view from any other view, and jumps to today once there (issue #149).
+ */
+import { test, expect } from '@playwright/test'
+import { clearState } from './fixtures/localstorage'
+
+test.describe('header — wordmark goes home', () => {
+  test.use({ viewport: { width: 1280, height: 800 } })
+
+  test('returns to month view, then to today', async ({ page }) => {
+    await clearState(page)
+    await page.goto('/year')
+    await expect(page.locator('[data-component="header"]')).toBeVisible()
+
+    const wordmark = page.locator('[data-component="brand-home"]')
+    await expect(wordmark).toHaveText('Calino')
+    await wordmark.click()
+    await expect(page).toHaveURL(/\/month$/)
+
+    // Walk a month ahead, then home again: month view's "home" is today.
+    const monthTitle = page.locator('[data-component="header"] h1')
+    const thisMonth = await monthTitle.textContent()
+    await page
+      .locator('[data-component="header"]')
+      .getByRole('button', { name: /next/i })
+      .first()
+      .click()
+    await expect(monthTitle).not.toHaveText(thisMonth!)
+    await wordmark.click()
+    await expect(monthTitle).toHaveText(thisMonth!)
+  })
+})

--- a/src/features/calendar/components/CalendarHeader.module.css
+++ b/src/features/calendar/components/CalendarHeader.module.css
@@ -29,14 +29,32 @@
 }
 
 /* ---- Brand Mark ---- */
+/* A button: the wordmark is the "home" control, back to month view. */
 .brand {
   display: flex;
   align-items: center;
   gap: 11px;
-  padding-left: 36px;
-  transition: opacity 0.2s ease, width 0.2s ease, padding 0.2s ease;
+  padding: 0 0 0 36px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  /* `visibility` rides along so a hidden wordmark drops out of the tab order,
+     flipping at the end of the fade-out and at the start of the fade-in. */
+  transition: opacity 0.2s ease, width 0.2s ease, padding 0.2s ease, visibility 0s;
   grid-column: 1;
   grid-row: 1;
+}
+
+.brand:hover .brandName {
+  color: var(--accent-strong, var(--accent));
+}
+
+.brand:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* Hidden when sidebar collapsed */
@@ -46,6 +64,8 @@
   overflow: hidden;
   padding: 0;
   pointer-events: none;
+  visibility: hidden;
+  transition: opacity 0.2s ease, width 0.2s ease, padding 0.2s ease, visibility 0s linear 0.2s;
 }
 
 .brandDiamond {
@@ -233,6 +253,23 @@
   top: 5px;
   /* See .navigator — same flex-shrink protection for the ≤768px flex layout. */
   flex-shrink: 0;
+}
+
+/* Outside week view the title is a button (month view, or today once there),
+   and has to look like one: the text I-beam gave no hint at all. */
+.titleClickable {
+  cursor: pointer;
+}
+
+.titleClickable:hover .monthTitle,
+.titleClickable:hover .viewTitle {
+  color: var(--accent-strong, var(--accent));
+}
+
+.titleClickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .monthTitle {
@@ -840,6 +877,7 @@
     overflow: hidden;
     padding: 0;
     pointer-events: none;
+    visibility: hidden;
   }
 
   .hamburger {

--- a/src/features/calendar/components/CalendarHeader.tsx
+++ b/src/features/calendar/components/CalendarHeader.tsx
@@ -460,8 +460,8 @@ export function CalendarHeader({
     )
   }
 
-  // Clicking the header title takes you back to month view from anywhere else;
-  // if you're already in month view it keeps the "jump to today" shortcut.
+  // The wordmark and the header title both act as "home": back to month view
+  // from anywhere else, and the "jump to today" shortcut once already there.
   const handleTitleClick = (): void => {
     if (currentView === 'month') {
       handleToday()
@@ -469,6 +469,8 @@ export function CalendarHeader({
       handleViewChange('month')
     }
   }
+  const homeLabel =
+    currentView === 'month' ? t('views.header.goToToday') : t('views.header.goToMonthView')
 
   const handleViewChange = useCallback(
     (view: ViewType) => {
@@ -529,10 +531,17 @@ export function CalendarHeader({
       data-component="header"
     >
       {/* Brand — hidden by CSS when sidebar collapsed or at compact breakpoint */}
-      <div className={styles.brand}>
-        <div className={styles.brandDiamond} />
+      <button
+        type="button"
+        className={styles.brand}
+        onClick={handleTitleClick}
+        aria-label={`Calino – ${homeLabel}`}
+        title={homeLabel}
+        data-component="brand-home"
+      >
+        <span className={styles.brandDiamond} />
         <span className={styles.brandName}>Calino</span>
-      </div>
+      </button>
       {/* Hamburger — shown by CSS when sidebar collapsed or at compact breakpoint */}
       <button
         className={styles.hamburger}
@@ -571,17 +580,12 @@ export function CalendarHeader({
       {/* Title — click returns to month view from anywhere (jumps to today when
           already in month) */}
       <div
-        className={styles.titleGroup}
+        className={`${styles.titleGroup} ${currentView === 'week' ? '' : styles.titleClickable}`}
         onClick={currentView === 'week' ? undefined : handleTitleClick}
         role={currentView === 'week' ? undefined : 'button'}
         tabIndex={currentView === 'week' ? undefined : 0}
-        aria-label={
-          currentView === 'week'
-            ? undefined
-            : currentView === 'month'
-              ? t('views.header.goToToday')
-              : t('views.header.goToMonthView')
-        }
+        aria-label={currentView === 'week' ? undefined : homeLabel}
+        title={currentView === 'week' ? undefined : homeLabel}
         onKeyDown={
           currentView === 'week'
             ? undefined


### PR DESCRIPTION
Fixes #149.

Two changes in `CalendarHeader`:

- The "Calino" wordmark is now a `<button>` wired to the same handler as the title: month view from any other view, today once you're in month view. Hover turns the name accent-coloured, there's a focus ring, and the `title` tooltip says what it does. The hidden states (sidebar collapsed, ≤950px) add `visibility: hidden` alongside the existing opacity/width fade so the button isn't a tab stop while invisible; `visibility` is on the transition list so it flips at the end of the fade-out and at the start of the fade-in.
- The header title, outside week view, gets `cursor: pointer`, the same hover colour on the month/view text, a focus ring, and the same tooltip. Behaviour is unchanged.

The `role="button"` on the title and its aria-label are as before. The wordmark's accessible name is "Calino – Go to month view" (or "– Go to today") so the visible text stays part of the name. No new locale strings; it reuses `goToMonthView` / `goToToday`.

Left alone: the sidebar's own copy of the wordmark in the mobile overlay. Making that navigate would also need to close the overlay, so it felt like a separate change.

New spec `e2e/header-home.spec.ts` (one test): wordmark from /year lands on /month, and after stepping a month ahead, the wordmark brings the title back to the current month. Typecheck, eslint on the file, the CalendarHeader unit tests and the week-window / month-layout / accessibility / keyboard-nav / mobile-ui specs pass in Chromium.
