### PR TITLE
fix(year): size the months to the window instead of a fixed 224px

### DIFF
--- a/e2e/year-layout.spec.ts
+++ b/e2e/year-layout.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * The year view sizes its months to the window (issue #148). The mini-months
+ * used to be capped at 224px with 26px cells, so on a large display the twelve
+ * cards were mostly padding and the page stopped at ~850px however tall the
+ * window was.
+ */
+import { test, expect, type Page } from '@playwright/test'
+import { clearState } from './fixtures/localstorage'
+
+async function yearGeometry(page: Page): Promise<{
+  clientHeight: number
+  scrollHeight: number
+  lastCardBottom: number
+  containerBottom: number
+  cell: number
+}> {
+  const container = page.locator('[data-component="year-view"]')
+  await expect(container).toBeVisible()
+  return container.evaluate((element) => {
+    const cards = element.querySelectorAll('[data-component="year-month"]')
+    const cell = element.querySelector('[data-component="year-day"]') as HTMLElement
+    return {
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+      lastCardBottom: cards[cards.length - 1].getBoundingClientRect().bottom,
+      containerBottom: element.getBoundingClientRect().bottom,
+      cell: cell.getBoundingClientRect().width,
+    }
+  })
+}
+
+test.describe('year layout', () => {
+  test('fills a large window without scrolling', async ({ page }) => {
+    await page.setViewportSize({ width: 2560, height: 1440 })
+    await clearState(page)
+    await page.goto('/year')
+
+    const g = await yearGeometry(page)
+    expect(g.scrollHeight).toBeLessThanOrEqual(g.clientHeight + 1)
+    // The last row of months reaches the bottom of the view, give or take the
+    // slack the height formula leaves on purpose.
+    expect(g.containerBottom - g.lastCardBottom).toBeLessThan(g.clientHeight * 0.1)
+    // Cells grew with the window: 54px here against the old fixed 26px.
+    expect(g.cell).toBeGreaterThan(40)
+  })
+
+  test('still fits a laptop window', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await clearState(page)
+    await page.goto('/year')
+
+    const g = await yearGeometry(page)
+    expect(g.scrollHeight).toBeLessThanOrEqual(g.clientHeight + 1)
+  })
+})

--- a/src/features/calendar/components/YearView.module.css
+++ b/src/features/calendar/components/YearView.module.css
@@ -8,6 +8,9 @@
   overflow: auto;
   padding: var(--space-4);
   margin: 0 var(--grid-margin, 16px) 24px 0;
+  /* Query container: `.grid` sizes itself off this box's height (cqh), so the
+     year fills a tall window instead of stopping at a fixed 850px. */
+  container-type: size;
 }
 
 @media (max-width: 768px) { /* sync with config.ts MOBILE_BREAKPOINT */
@@ -25,27 +28,69 @@
   }
 }
 
+/* The mini-months are fluid (see .dayGrid), so the grid's width is what
+   decides how big a year gets. Two things bound it: the container's width, as
+   for any block, and a width worked back from the container's *height*, so
+   that `--year-rows` rows of cards fit without scrolling. Below a floor — a
+   card about the size this view has always drawn — the grid stops shrinking
+   and the container scrolls instead, as it did before. */
 .grid {
+  --year-cols: 4;
+  --year-rows: 3;
+  --year-gap: 14px;
+  --year-card-min: 224px;
+  /* The card height that stacks `--year-rows` of them in the container. */
+  --year-card-h: calc((100cqh - (var(--year-rows) - 1) * var(--year-gap)) / var(--year-rows));
+  /* The card width that yields that height. A card is 80–93px of chrome —
+     header, weekday row, cell gaps and padding, more as the type grows with the
+     card — plus six rows of square cells, each a seventh of what's left after
+     the 28px padding and 12px of column gaps. 102px of chrome errs towards a
+     little room at the bottom rather than a scrollbar for a few px. */
+  --year-card-w: calc(40px + (var(--year-card-h) - 102px) * 7 / 6);
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 14px;
+  grid-template-columns: repeat(var(--year-cols), 1fr);
+  gap: var(--year-gap);
+  margin: 0 auto;
+  max-width: max(
+    calc(var(--year-cols) * var(--year-card-min) + (var(--year-cols) - 1) * var(--year-gap)),
+    calc(var(--year-cols) * var(--year-card-w) + (var(--year-cols) - 1) * var(--year-gap))
+  );
+}
+
+/* The week-number column is 0.6 of a cell wide, so the same height comes
+   from a wider card: 7.6 tracks and one more gap. */
+.gridWithWeekNum {
+  --year-card-w: calc(42px + (var(--year-card-h) - 102px) * 7.6 / 6);
 }
 
 @media (max-width: 1100px) {
   .grid {
-    grid-template-columns: repeat(3, 1fr);
+    --year-cols: 3;
+    --year-rows: 4;
   }
 }
 
 @media (max-width: 768px) {
   .grid {
-    grid-template-columns: repeat(2, 1fr);
+    --year-cols: 2;
+    --year-rows: 6;
   }
 }
 
 @media (max-width: 500px) {
   .grid {
-    grid-template-columns: 1fr;
+    --year-cols: 1;
+    --year-rows: 12;
+    /* One column always scrolls; nothing to fit to. */
+    max-width: none;
+  }
+
+  /* A phone-width card is wider than a month wants to be: cells the full
+     width made each month a screen tall. Keep the card, cap the month. */
+  .weekdayRow,
+  .dayGrid {
+    max-width: 240px;
+    margin-inline: auto;
   }
 }
 
@@ -59,6 +104,8 @@
   flex-direction: column;
   cursor: pointer;
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
+  /* Type inside the card scales with the card (cqw below). */
+  container-type: inline-size;
 }
 
 .month:hover {
@@ -72,7 +119,7 @@
   border: none;
   padding: 0 0 8px;
   text-align: center;
-  font-size: 14px;
+  font-size: clamp(14px, 4.5cqw, 20px);
   font-weight: 600;
   color: var(--ink, #2c2823);
   cursor: pointer;
@@ -83,17 +130,20 @@
   color: var(--accent-strong, var(--accent, #b07d4f));
 }
 
+/* Seven equal tracks the full width of the card: the cells are squares
+   (aspect-ratio) so the month grows with the card rather than sitting in a
+   fixed 224px box in the middle of it. */
 .weekdayRow {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
+  gap: 0 2px;
   width: 100%;
-  max-width: 224px;
-  margin: 0 auto 2px;
+  margin: 0 0 2px;
 }
 
 .weekdayInitial {
   text-align: center;
-  font-size: 10px;
+  font-size: clamp(10px, 3.2cqw, 14px);
   color: var(--ink-muted, var(--ink-3, #9c9384));
   line-height: 1.5;
 }
@@ -101,27 +151,25 @@
 .dayGrid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
   width: 100%;
-  max-width: 224px;
-  margin: 0 auto;
 }
 
 /* Leading ISO week-number column (when "Show week numbers" is enabled) */
 .weekdayRow.withWeekNum,
 .dayGrid.withWeekNum {
-  grid-template-columns: 20px repeat(7, 1fr);
-  max-width: 244px;
+  grid-template-columns: 0.6fr repeat(7, 1fr);
 }
 
 .weekNum {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 26px;
-  margin: 1px auto;
+  width: 100%;
+  height: 100%;
+  margin: 0;
   padding: 0;
-  font-size: 9.5px;
+  font-size: clamp(9.5px, 3cqw, 13px);
   font-variant-numeric: tabular-nums;
   color: var(--ink-muted, var(--ink-3, #9c9384));
   background: none;
@@ -138,9 +186,9 @@
 
 .day,
 .emptyDay {
-  width: 26px;
-  height: 26px;
-  margin: 1px auto;
+  width: 100%;
+  aspect-ratio: 1;
+  margin: 0;
 }
 
 .day {
@@ -148,7 +196,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: clamp(11px, 3.6cqw, 16px);
+  padding: 0;
   color: var(--ink, #2c2823);
   background: none;
   border: none;
@@ -179,11 +228,11 @@
 
 .eventDot {
   position: absolute;
-  bottom: 2px;
+  bottom: clamp(2px, 0.8cqw, 5px);
   left: 50%;
   transform: translateX(-50%);
-  width: 3px;
-  height: 3px;
+  width: clamp(3px, 1cqw, 5px);
+  height: clamp(3px, 1cqw, 5px);
   border-radius: 50%;
   background: var(--accent, #b07d4f);
 }

--- a/src/features/calendar/components/YearView.tsx
+++ b/src/features/calendar/components/YearView.tsx
@@ -100,8 +100,8 @@ export function YearView(): JSX.Element {
   }
 
   return (
-    <div className={styles.container}>
-      <div className={styles.grid}>
+    <div className={styles.container} data-component="year-view">
+      <div className={`${styles.grid} ${showWeekNumbers ? styles.gridWithWeekNum : ''}`}>
         {months.map((m) => {
           const days = eachDayOfInterval({
             start: startOfWeek(startOfMonth(m), { weekStartsOn: firstDayOfWeek }),
@@ -119,6 +119,7 @@ export function YearView(): JSX.Element {
               className={styles.month}
               role="button"
               tabIndex={0}
+              data-component="year-month"
               onClick={() => handleMonthClick(m)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
@@ -171,6 +172,7 @@ export function YearView(): JSX.Element {
                           <button
                             key={dayKey}
                             className={`${styles.day} ${isTodayDate ? styles.today : ''}`}
+                            data-component="year-day"
                             onClick={(e) => handleDayClick(day, e)}
                           >
                             {format(day, 'd')}


### PR DESCRIPTION
Fixes #148.

CSS in `YearView.module.css`, plus three `data-component` hooks and one class toggle in the TSX.

- `.dayGrid` / `.weekdayRow` lose their 224px cap; cells are `1fr` tracks with `aspect-ratio: 1` instead of a fixed 26px, and the digits, weekday initials, month header and event dot scale with the card via `cqw` (the card is an `inline-size` container, same as `JournalView` already does).
- `.grid` gets a `max-width` worked back from the container's height, so `--year-rows` rows of cards fit without scrolling: card height = (100cqh − gaps) / rows, and card width = 40px + (height − 102px) × 7/6, i.e. ~100px of chrome plus six rows of square cells. With week numbers on, the grid carries `.gridWithWeekNum` and uses 7.6 tracks instead of 7. The formula deliberately leaves a little room at the bottom (36–75px across the sizes I measured) rather than risk a scrollbar for a few px.
- Below a floor of 224px per card the grid stops shrinking and the container scrolls, which is what it did before on short windows.
- On the single-column phone layout the month is capped at 240px inside the full-width card, so a month is about as tall as it was (33px cells instead of 26px).

Measured in Chromium, week numbers on:

| viewport | card | cell | scrolls? |
|---|---|---|---|
| 1440×900 | 225px | 24px | no (was: no) |
| 1920×1080 | 301px | 34px | no |
| 2000×1210 | 356px | 41px | no |
| 2560×1440 | 453px | 54px | no |
| 1280×800 | 223px | 24px | yes (was: yes) |

Before, the card grew with the column but the month inside stayed at 244px / 26px cells at every size, and the page ended at ~850px.

`e2e/year-layout.spec.ts` checks that 2560×1440 fills the view without scrolling with cells over 40px, and that 1440×900 still fits. Typecheck, eslint on the touched files, and the accessibility / mobile-ui / keyboard-nav specs pass.
