### PR TITLE
fix(agenda): colour a task's bar by its category like an event's

### DIFF
--- a/e2e/agenda.spec.ts
+++ b/e2e/agenda.spec.ts
@@ -19,6 +19,7 @@ async function seedAgendaItems(page: Page): Promise<void> {
         const parsed = raw ? JSON.parse(raw) : { state: {}, version: 2 }
         parsed.state = {
           ...(parsed.state ?? {}),
+          categories: [{ id: 'agenda-cat', name: 'Focus', color: '#3b82f6' }],
           events: [
             ...(parsed.state?.events ?? []),
             {
@@ -29,6 +30,7 @@ async function seedAgendaItems(page: Page): Promise<void> {
               end: `${today}T10:00:00`,
               isAllDay: false,
               calendarId: 'default',
+              categories: ['Focus'],
             },
             {
               id: 'agenda-parent',
@@ -63,6 +65,7 @@ async function seedAgendaItems(page: Page): Promise<void> {
               isAllDay: true,
               calendarId: 'default',
               completed: false,
+              categories: ['Focus'],
             },
           ],
         }
@@ -209,6 +212,29 @@ test('agenda indents subtasks and moves tasks and events between days', async ({
       agendaEvent.evaluate((element) => getComputedStyle(element.parentElement as Element).overflow)
     )
     .toBe('visible')
+})
+
+test('agenda colours a task row by its category like an event row', async ({ page }) => {
+  await clearState(page)
+  await seedAgendaItems(page)
+  await page.goto('/agenda')
+
+  const today = localDate()
+  await expect(page.locator(`[data-date="${today}"]`)).toBeVisible()
+
+  // The bar is each row's first child; both rows are in the "Focus" category.
+  const eventBar = page
+    .locator('[data-component="agenda-event"]')
+    .filter({ hasText: 'Agenda event' })
+    .locator('> div')
+    .first()
+  const taskBar = page
+    .locator('[data-component="agenda-task"]')
+    .filter({ hasText: 'Agenda task' })
+    .locator('> div')
+    .first()
+  await expect(eventBar).toHaveCSS('background-color', 'rgb(59, 130, 246)')
+  await expect(taskBar).toHaveCSS('background-color', 'rgb(59, 130, 246)')
 })
 
 test('agenda collapses consecutive empty dates into a free-range row', async ({ page }) => {

--- a/src/features/calendar/components/AgendaView.module.css
+++ b/src/features/calendar/components/AgendaView.module.css
@@ -362,6 +362,7 @@
 .agendaTaskBar {
   width: 3px;
   flex-shrink: 0;
+  /* Inline style carries the category/calendar colour, as on event rows. */
   background: var(--ink-3, #a39d93);
 }
 

--- a/src/features/calendar/components/AgendaView.tsx
+++ b/src/features/calendar/components/AgendaView.tsx
@@ -760,7 +760,10 @@ export function AgendaView({ embedded = false }: { embedded?: boolean } = {}): J
                                         onContextMenu={(e) => handleEventContextMenu(e, event)}
                                         disableKeyboardAttributes
                                       >
-                                        <div className={styles.agendaTaskBar} />
+                                        <div
+                                          className={styles.agendaTaskBar}
+                                          style={{ background: getEventBarColor(event) }}
+                                        />
                                         <div
                                           className={styles.agendaTaskBody}
                                           data-task-depth={taskDepthById.get(event.id) ?? 0}


### PR DESCRIPTION
Fixes #154.

The task row now sets the same inline `background` on `.agendaTaskBar` that the event row sets on `.agendaEventBar`, via the existing `getEventBarColor`. So a task follows `event.color` → category colour (when "Use category colours" is on) → calendar colour, the same chain events use; the grey stays as the CSS fallback. Tasks are still told apart by the checkbox, the "Due" label and the row background.

`e2e/agenda.spec.ts`: the seeded event and task now sit in a "Focus" category, and a new test asserts both bars render its colour. One note: `agenda indents subtasks and moves tasks and events between days` in that file fails for me on an untouched main as well (a drag assertion), so I've left it alone.

Typecheck and eslint on the touched files pass.
