### PR TITLE
feat(sync): carry category colours and auto-category rules with settings

### DIFF
--- a/docs/CALINOSETTINGSSYNC.md
+++ b/docs/CALINOSETTINGSSYNC.md
@@ -124,9 +124,16 @@ The `ATTACH` field contains base64-encoded JSON:
     "useCategoryColors": true,
     "journalEnabled": false,
     "taskCollapseOverrides": {}
-  }
+  },
+  "categories": [{ "id": "…", "name": "Work", "color": "#b07d4f" }],
+  "autoCategoryRules": [{ "id": "…", "keywords": ["standup"], "categoryId": "…" }]
 }
 ```
+
+`categories` and `autoCategoryRules` come from the calendar store rather than
+the settings store. Both are optional in the payload: one written by a build
+that predates them has neither, and a reader treats that as "leave mine alone"
+rather than "delete everything".
 
 ### What's Synced vs. What's Not
 
@@ -136,7 +143,7 @@ The `ATTACH` field contains base64-encoded JSON:
 - Default view, event density, week numbers
 - Theme mode, light/dark theme names, and both Adjustable theme profiles
 - Notification preferences
-- Category colors, completed task visibility
+- Category colours and auto-category keyword rules, completed task visibility
 
 **NOT synced** (local-only):
 
@@ -166,6 +173,23 @@ Remote DTSTAMP ≤ lastSyncedAt  →  Local wins (we're up to date or ahead)
 `lastModified` instead. The comparison is against the last remote `DTSTAMP`, so a
 remote write that happened after the last pull can still win.
 
+### Categories
+
+Settings are scalars, so "remote wins" copies each one over. Categories are a
+list whose ids differ per device — calendar sync creates any `CATEGORIES` value
+it hasn't seen as a new category with a fresh UUID and a random colour — so the
+merge (`mergeCategories`) keys on **name**:
+
+- A name both sides have takes the remote colour and keeps the local id.
+- A name only the remote has is added.
+- A name only the local side has is kept. Deletions don't travel: the server's
+  events still carry the name, so the next calendar sync would recreate the
+  category anyway.
+
+Auto-category rules reference a category by id, so each remote rule is
+re-pointed through the category name at the local id; a rule whose category
+can't be resolved is dropped. Rules merge by their own id, remote copy winning.
+
 ## Sync Flow
 
 ### Pull (Automatic)
@@ -178,7 +202,7 @@ Happens as part of the normal CalDAV calendar sync cycle:
 4. Fetch settings VEVENT via REPORT (UID filter)
 5. Extract base64 from ATTACH, decode, parse JSON
 6. Compare `DTSTAMP` vs `lastSyncedAt`
-7. If remote wins → merge settings into Zustand store
+7. If remote wins → `applyRemotePayload`: merge settings into the settings store, categories into the calendar store
 8. Update `lastSyncedAt`
 
 ### Push (Manual)

--- a/e2e/settings-sync.spec.ts
+++ b/e2e/settings-sync.spec.ts
@@ -40,6 +40,9 @@ function buildSettingsVCalendar(firstDayOfWeek: number): string {
     version: 1,
     syncedAt: new Date().toISOString(),
     settings: { firstDayOfWeek },
+    // Category colours ride along with the settings (issue #155).
+    categories: [{ id: 'remote-focus', name: 'Focus', color: '#3b82f6' }],
+    autoCategoryRules: [{ id: 'remote-rule', keywords: ['deep work'], categoryId: 'remote-focus' }],
   }
   const json = JSON.stringify(payload)
   // Match the base64 charset Calino uses: standard alphabet, padded.
@@ -155,6 +158,13 @@ test.describe('CalDAV settings sync', () => {
     await expect(
       page.getByRole('radio', { name: 'Sunday' })
     ).toHaveAttribute('aria-checked', 'true')
+
+    // The category came across with its colour, and its rule with it.
+    await page.locator('[data-component="settings-nav-item"][data-tab="categories"]').click()
+    await expect(
+      page.locator('[data-component="category-row"][data-category-name="Focus"]')
+    ).toHaveAttribute('data-category-color', '#3b82f6')
+    await expect(page.getByText('deep work')).toBeVisible()
   })
 
   // R1.22 regression — the auto-discovery toast must not lie.

--- a/src/features/caldav/hooks/useCalDAV.ts
+++ b/src/features/caldav/hooks/useCalDAV.ts
@@ -1277,7 +1277,7 @@ export function useCalDAVInstance(): UseCalDAVReturn {
             deriveCalendarHomeUrl,
             dtstampToISO,
             deserializeSettings,
-            mergeSettings,
+            applyRemotePayload,
             resolveConflict,
             setLastSyncedAt,
           } = await import('@/lib/settingsSync')
@@ -1300,14 +1300,9 @@ export function useCalDAVInstance(): UseCalDAVReturn {
                 if (json) {
                   const parsed = deserializeSettings(json)
                   if (parsed) {
-                    const localSettings = useSettingsStore.getState()
                     const dtstampIso = dtstampToISO(remote.dtstamp)
                     const winner = resolveConflict(new Date(0).toISOString(), dtstampIso)
-                    const merged =
-                      winner === 'remote'
-                        ? mergeSettings(localSettings, parsed.settings)
-                        : localSettings
-                    useSettingsStore.getState().updateSettings(merged)
+                    if (winner === 'remote') applyRemotePayload(parsed)
                     appliedRemote = true
                   }
                 }
@@ -1938,7 +1933,7 @@ export function useCalDAVInstance(): UseCalDAVReturn {
             deriveCalendarHomeUrl,
             dtstampToISO,
             deserializeSettings,
-            mergeSettings,
+            applyRemotePayload,
             resolveConflict,
             setEtag,
             setLastSyncedAt,
@@ -1962,17 +1957,13 @@ export function useCalDAVInstance(): UseCalDAVReturn {
                   if (json) {
                     const parsed = deserializeSettings(json)
                     if (parsed) {
-                      const localSettings = useSettingsStore.getState()
                       const dtstampIso = dtstampToISO(remote.dtstamp)
                       const localSyncedAt = getLastSyncedAt()
                       const winner = resolveConflict(
                         localSyncedAt || '1970-01-01T00:00:00Z',
                         dtstampIso
                       )
-                      if (winner === 'remote') {
-                        const merged = mergeSettings(localSettings, parsed.settings)
-                        useSettingsStore.getState().updateSettings(merged)
-                      }
+                      if (winner === 'remote') applyRemotePayload(parsed)
                       setLastSyncedAt(new Date().toISOString())
                     }
                   }

--- a/src/features/commandPalette/__tests__/useCommandPalette.test.ts
+++ b/src/features/commandPalette/__tests__/useCommandPalette.test.ts
@@ -82,6 +82,7 @@ vi.mock('@/store/calendarStore', () => ({
       addAutoCategoryRule: vi.fn(),
       updateAutoCategoryRule: vi.fn(),
       deleteAutoCategoryRule: vi.fn(),
+      applySyncedCategories: vi.fn(),
       toggleCategoryFilter: vi.fn(),
       setCurrentDate: vi.fn(),
       setCurrentView: vi.fn(),

--- a/src/hooks/__tests__/useSettingsSync.test.ts
+++ b/src/hooks/__tests__/useSettingsSync.test.ts
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react'
 import { createLocalStorageMock } from '@/test/storageMock'
 import { useSettingsSync } from '../useSettingsSync'
 import { useSettingsStore } from '@/store/settingsStore'
+import { useCalendarStore } from '@/store/calendarStore'
 import {
   getPrimaryAccountId,
   getEtag,
@@ -61,6 +62,7 @@ describe('useSettingsSync', () => {
     vi.clearAllMocks()
     storage.install()
     useSettingsStore.getState().resetSettings()
+    useCalendarStore.setState({ categories: [], autoCategoryRules: [] })
     vi.mocked(createCalDAVClient).mockResolvedValue(
       mockClient as unknown as Awaited<ReturnType<typeof createCalDAVClient>>
     )
@@ -281,6 +283,8 @@ describe('useSettingsSync', () => {
         version: 1,
         syncedAt: '2099-01-01T00:00:00Z',
         settings: { timezone: 'Pacific/Auckland' },
+        categories: [{ id: 'remote-work', name: 'Work', color: '#ff0000' }],
+        autoCategoryRules: [{ id: 'r1', keywords: ['standup'], categoryId: 'remote-work' }],
       }
       mockFetchSettingsEvent.mockResolvedValue({
         data:
@@ -301,6 +305,11 @@ describe('useSettingsSync', () => {
       const settings = useSettingsStore.getState()
       expect(settings.timezone).toBe('Pacific/Auckland')
       expect(getLastSyncedAt()).toBeTruthy()
+      const { categories, autoCategoryRules } = useCalendarStore.getState()
+      expect(categories).toEqual([{ id: 'remote-work', name: 'Work', color: '#ff0000' }])
+      expect(autoCategoryRules).toEqual([
+        { id: 'r1', keywords: ['standup'], categoryId: 'remote-work' },
+      ])
     })
 
     it('should return early when no remote event exists', async () => {

--- a/src/hooks/useSettingsSync.ts
+++ b/src/hooks/useSettingsSync.ts
@@ -17,7 +17,7 @@ import { useSettingsStore } from '@/store/settingsStore'
 import {
   serializeSettings,
   deserializeSettings,
-  mergeSettings,
+  applyRemotePayload,
   resolveConflict,
   encodeBase64,
   deriveCalendarHomeUrl,
@@ -113,22 +113,6 @@ export function useSettingsSync(): UseSettingsSyncReturn {
     return discovered?.url ?? null
   }
 
-  function resolveAndMerge(
-    localSettings: ReturnType<typeof useSettingsStore.getState>,
-    remoteSettings: {
-      settings: Partial<ReturnType<typeof useSettingsStore.getState>>
-      syncedAt: string
-    },
-    remoteDtstamp: string
-  ): ReturnType<typeof useSettingsStore.getState> {
-    const lastSynced = getLastSyncedAt() || '1970-01-01T00:00:00Z'
-    const winner = resolveConflict(lastSynced, remoteDtstamp || remoteSettings.syncedAt)
-    if (winner === 'remote') {
-      return { ...localSettings, ...mergeSettings(localSettings, remoteSettings.settings) }
-    }
-    return localSettings
-  }
-
   // ── Core operations ─────────────────────────────────────────────────────────
 
   // pull is defined before push so push can reference it in its dependency array.
@@ -189,9 +173,10 @@ export function useSettingsSync(): UseSettingsSyncReturn {
       }
 
       const dtstampIso = dtstampToISO(remote.dtstamp)
-      const localSettings = useSettingsStore.getState()
-      const merged = resolveAndMerge(localSettings, parsed, dtstampIso)
-      useSettingsStore.getState().updateSettings(merged)
+      const lastSynced = getLastSyncedAt() || '1970-01-01T00:00:00Z'
+      if (resolveConflict(lastSynced, dtstampIso || parsed.syncedAt) === 'remote') {
+        applyRemotePayload(parsed)
+      }
       setEtag(remote.etag)
       // Store the actual DTSTAMP from the server — shows when settings were truly last written
       setLastSyncedAt(dtstampIso || new Date().toISOString())

--- a/src/lib/__tests__/settingsSync.test.ts
+++ b/src/lib/__tests__/settingsSync.test.ts
@@ -4,6 +4,8 @@ import {
   serializeSettings,
   deserializeSettings,
   mergeSettings,
+  mergeCategories,
+  applyRemotePayload,
   resolveConflict,
   encodeBase64,
   decodeBase64,
@@ -25,6 +27,7 @@ import {
   type SettingsSyncPayload,
 } from '../settingsSync'
 import { useSettingsStore } from '@/store/settingsStore'
+import { useCalendarStore } from '@/store/calendarStore'
 
 describe('settingsSync', () => {
   const storage = createLocalStorageMock()
@@ -32,6 +35,7 @@ describe('settingsSync', () => {
   beforeEach(() => {
     storage.install()
     useSettingsStore.getState().resetSettings()
+    useCalendarStore.setState({ categories: [], autoCategoryRules: [] })
   })
 
   afterEach(() => {
@@ -130,6 +134,18 @@ describe('settingsSync', () => {
       const parsed = JSON.parse(serializeSettings()) as SettingsSyncPayload
       expect(parsed.settings.taskCollapseOverrides).toEqual({ parent: true })
     })
+
+    it('should include category colours and auto-category rules', () => {
+      useCalendarStore.setState({
+        categories: [{ id: 'c1', name: 'Work', color: '#ff0000' }],
+        autoCategoryRules: [{ id: 'r1', keywords: ['standup'], categoryId: 'c1' }],
+      })
+      const parsed = JSON.parse(serializeSettings()) as SettingsSyncPayload
+      expect(parsed.categories).toEqual([{ id: 'c1', name: 'Work', color: '#ff0000' }])
+      expect(parsed.autoCategoryRules).toEqual([
+        { id: 'r1', keywords: ['standup'], categoryId: 'c1' },
+      ])
+    })
   })
 
   describe('deserializeSettings', () => {
@@ -156,6 +172,105 @@ describe('settingsSync', () => {
     it('should return null for missing settings', () => {
       const payload = { version: SYNC_FORMAT_VERSION, syncedAt: '' }
       expect(deserializeSettings(JSON.stringify(payload))).toBeNull()
+    })
+
+    it('should leave the category lists out when the payload has none', () => {
+      // A payload from a build that predates category sync.
+      const payload = { version: SYNC_FORMAT_VERSION, syncedAt: '', settings: {} }
+      const result = deserializeSettings(JSON.stringify(payload))
+      expect(result?.categories).toBeUndefined()
+      expect(result?.autoCategoryRules).toBeUndefined()
+    })
+  })
+
+  describe('mergeCategories', () => {
+    const local = {
+      categories: [
+        { id: 'local-work', name: 'Work', color: '#111111' },
+        { id: 'local-home', name: 'Home', color: '#222222' },
+      ],
+      autoCategoryRules: [{ id: 'rule-home', keywords: ['chores'], categoryId: 'local-home' }],
+    }
+
+    it('should return the local lists untouched when the remote sent none', () => {
+      expect(mergeCategories(local, {})).toBe(local)
+    })
+
+    it('should return the local lists untouched when the remote matches them', () => {
+      const remote = {
+        categories: [{ id: 'other-device', name: 'Work', color: '#111111' }],
+        autoCategoryRules: [{ id: 'rule-home', keywords: ['chores'], categoryId: 'no-home-here' }],
+      }
+      // The remote rule can't be resolved, so it drops out and the local one stays.
+      expect(mergeCategories(local, remote)).toBe(local)
+    })
+
+    it('should take the remote colour for a name both sides have, keeping the local id', () => {
+      const merged = mergeCategories(local, {
+        categories: [{ id: 'remote-work', name: 'Work', color: '#ff0000' }],
+      })
+      expect(merged.categories).toEqual([
+        { id: 'local-work', name: 'Work', color: '#ff0000' },
+        { id: 'local-home', name: 'Home', color: '#222222' },
+      ])
+    })
+
+    it('should add a category only the remote has and keep one only the local has', () => {
+      const merged = mergeCategories(local, {
+        categories: [{ id: 'remote-gym', name: 'Gym', color: '#00ff00' }],
+      })
+      expect(merged.categories.map((c) => c.name)).toEqual(['Work', 'Home', 'Gym'])
+      expect(merged.categories[2].id).toBe('remote-gym')
+    })
+
+    it('should re-point remote rules at the local category of the same name', () => {
+      const merged = mergeCategories(local, {
+        categories: [{ id: 'remote-work', name: 'Work', color: '#111111' }],
+        autoCategoryRules: [{ id: 'rule-work', keywords: ['standup'], categoryId: 'remote-work' }],
+      })
+      expect(merged.autoCategoryRules).toEqual([
+        { id: 'rule-home', keywords: ['chores'], categoryId: 'local-home' },
+        { id: 'rule-work', keywords: ['standup'], categoryId: 'local-work' },
+      ])
+    })
+
+    it('should replace a local rule with the remote copy of the same id and drop unresolvable ones', () => {
+      const merged = mergeCategories(local, {
+        categories: [{ id: 'remote-home', name: 'Home', color: '#222222' }],
+        autoCategoryRules: [
+          { id: 'rule-home', keywords: ['chores', 'laundry'], categoryId: 'remote-home' },
+          { id: 'rule-orphan', keywords: ['?'], categoryId: 'no-such-category' },
+        ],
+      })
+      expect(merged.autoCategoryRules).toEqual([
+        { id: 'rule-home', keywords: ['chores', 'laundry'], categoryId: 'local-home' },
+      ])
+    })
+  })
+
+  describe('applyRemotePayload', () => {
+    it('should write settings and categories to their stores', () => {
+      useCalendarStore.setState({
+        categories: [{ id: 'local-work', name: 'Work', color: '#111111' }],
+        autoCategoryRules: [],
+      })
+      applyRemotePayload({
+        settings: { timezone: 'Pacific/Auckland' },
+        categories: [{ id: 'remote-work', name: 'Work', color: '#ff0000' }],
+        autoCategoryRules: [{ id: 'r1', keywords: ['standup'], categoryId: 'remote-work' }],
+      })
+      expect(useSettingsStore.getState().timezone).toBe('Pacific/Auckland')
+      const { categories, autoCategoryRules } = useCalendarStore.getState()
+      expect(categories).toEqual([{ id: 'local-work', name: 'Work', color: '#ff0000' }])
+      expect(autoCategoryRules).toEqual([
+        { id: 'r1', keywords: ['standup'], categoryId: 'local-work' },
+      ])
+    })
+
+    it('should leave the calendar store alone when the payload has no categories', () => {
+      const before = useCalendarStore.getState().categories
+      applyRemotePayload({ settings: { timezone: 'Pacific/Auckland' } })
+      expect(useCalendarStore.getState().categories).toBe(before)
     })
   })
 

--- a/src/lib/settingsSync.ts
+++ b/src/lib/settingsSync.ts
@@ -11,7 +11,9 @@ import {
   normalizeAdjustableTheme,
   useSettingsStore,
 } from '@/store/settingsStore'
+import { useCalendarStore } from '@/store/calendarStore'
 import type { UserSettings } from '@/types'
+import type { AutoCategoryRule, Category } from '@/types/categories'
 
 // ─── Version ──────────────────────────────────────────────────────────────────
 
@@ -25,6 +27,21 @@ export interface SettingsSyncPayload {
   version: number
   syncedAt: string
   settings: Partial<UserSettings>
+  /**
+   * Category colours and the keyword rules that file events under them. They
+   * live in the calendar store, not the settings store, but they are as
+   * Calino-only as any setting: the name travels on each event as CATEGORIES,
+   * the colour has nowhere else to go. Optional because a payload written by
+   * an older build has neither, and that has to mean "leave mine alone".
+   */
+  categories?: Category[]
+  autoCategoryRules?: AutoCategoryRule[]
+}
+
+/** The two category lists as they sit in the calendar store. */
+export interface SyncedCategories {
+  categories: Category[]
+  autoCategoryRules: AutoCategoryRule[]
 }
 
 // ─── Syncable fields ──────────────────────────────────────────────────────────
@@ -95,10 +112,13 @@ export function serializeSettings(): string {
       ;(syncableSettings as Record<string, unknown>)[key] = state[key]
     }
   }
+  const calendarState = useCalendarStore.getState()
   const payload: SettingsSyncPayload = {
     version: SYNC_FORMAT_VERSION,
     syncedAt: new Date().toISOString(),
     settings: syncableSettings,
+    categories: calendarState.categories,
+    autoCategoryRules: calendarState.autoCategoryRules,
   }
   return JSON.stringify(payload, null, 2)
 }
@@ -110,6 +130,8 @@ export function serializeSettings(): string {
 export function deserializeSettings(json: string): {
   settings: Partial<UserSettings>
   syncedAt: string
+  categories?: Category[]
+  autoCategoryRules?: AutoCategoryRule[]
 } | null {
   try {
     const payload = JSON.parse(json) as SettingsSyncPayload
@@ -121,7 +143,15 @@ export function deserializeSettings(json: string): {
       console.warn('[SettingsSync] Invalid settings payload')
       return null
     }
-    return { settings: payload.settings, syncedAt: payload.syncedAt }
+    return {
+      settings: payload.settings,
+      syncedAt: payload.syncedAt,
+      // Anything that isn't a list is treated as "not sent".
+      ...(Array.isArray(payload.categories) ? { categories: payload.categories } : {}),
+      ...(Array.isArray(payload.autoCategoryRules)
+        ? { autoCategoryRules: payload.autoCategoryRules }
+        : {}),
+    }
   } catch (error) {
     console.warn('[SettingsSync] Failed to parse settings JSON:', error)
     return null
@@ -153,6 +183,98 @@ export function mergeSettings(
     }
   }
   return merged
+}
+
+/**
+ * Merge remote category lists onto local ones.
+ *
+ * Categories are keyed by *name*, not id. Every device mints its own id: sync
+ * creates an unseen CATEGORIES value as a new category with a fresh UUID and
+ * a random colour, so the same "Work" has a different id on every device.
+ * Events reference categories by name, so a name-keyed merge is what makes a
+ * remote colour land on the right thing. A rule references its category by id,
+ * so each remote rule is re-pointed through the name at the local category.
+ *
+ * The merge is additive on purpose. A remote colour wins for a name both sides
+ * have, a name only the remote has is added, and a name only the local side
+ * has is kept: a deletion can't travel this way regardless, because the
+ * server's events still carry the name and the next calendar sync would put
+ * the category straight back. Rules merge by their own id the same way.
+ *
+ * A remote payload with no lists at all — written by a build that didn't
+ * send them — leaves the local lists untouched.
+ */
+export function mergeCategories(
+  local: SyncedCategories,
+  remote: Partial<SyncedCategories>
+): SyncedCategories {
+  if (!remote.categories) return local
+
+  // Returns `local` itself when nothing differs, so callers can skip the
+  // store write (and the cache invalidation that comes with it).
+  let changed = false
+  const categories = local.categories.map((category) => {
+    const match = remote.categories!.find((c) => c.name === category.name)
+    if (!match || match.color === category.color) return category
+    changed = true
+    return { ...category, color: match.color }
+  })
+  const localNames = new Set(local.categories.map((c) => c.name))
+  const localIds = new Set(local.categories.map((c) => c.id))
+  for (const category of remote.categories) {
+    if (localNames.has(category.name) || localIds.has(category.id)) continue
+    categories.push(category)
+    localNames.add(category.name)
+    localIds.add(category.id)
+    changed = true
+  }
+
+  let autoCategoryRules = local.autoCategoryRules
+  if (remote.autoCategoryRules) {
+    // Remote rule → remote category → its name → the merged category's id.
+    const remoteNameById = new Map(remote.categories.map((c) => [c.id, c.name]))
+    const mergedIdByName = new Map(categories.map((c) => [c.name, c.id]))
+    const remapped: AutoCategoryRule[] = []
+    for (const rule of remote.autoCategoryRules) {
+      const name = remoteNameById.get(rule.categoryId)
+      const categoryId = name ? mergedIdByName.get(name) : undefined
+      if (categoryId) remapped.push({ ...rule, categoryId })
+    }
+    const remoteRuleIds = new Set(remapped.map((r) => r.id))
+    const kept = local.autoCategoryRules.filter((r) => !remoteRuleIds.has(r.id))
+    const next = [...kept, ...remapped]
+    if (JSON.stringify(next) !== JSON.stringify(local.autoCategoryRules)) {
+      autoCategoryRules = next
+      changed = true
+    }
+  }
+
+  return changed ? { categories, autoCategoryRules } : local
+}
+
+/**
+ * Apply a remote payload that has won conflict resolution: settings onto the
+ * settings store, categories onto the calendar store. The three places that
+ * pull settings — the hook, the account-add discovery and the post-sync
+ * pull in `useCalDAV` — all go through here so they can't drift.
+ */
+export function applyRemotePayload(remote: {
+  settings: Partial<UserSettings>
+  categories?: Category[]
+  autoCategoryRules?: AutoCategoryRule[]
+}): void {
+  const settingsStore = useSettingsStore.getState()
+  settingsStore.updateSettings(mergeSettings(settingsStore, remote.settings))
+
+  const calendarStore = useCalendarStore.getState()
+  const local: SyncedCategories = {
+    categories: calendarStore.categories,
+    autoCategoryRules: calendarStore.autoCategoryRules,
+  }
+  const merged = mergeCategories(local, remote)
+  if (merged !== local) {
+    calendarStore.applySyncedCategories(merged.categories, merged.autoCategoryRules)
+  }
 }
 
 // ─── Conflict resolution helpers ──────────────────────────────────────────────

--- a/src/store/calendarStore.ts
+++ b/src/store/calendarStore.ts
@@ -1215,6 +1215,16 @@ export const useCalendarStore = create<CalendarStore>()(
         }))
       },
 
+      applySyncedCategories: (
+        categories: Category[],
+        autoCategoryRules: AutoCategoryRule[]
+      ): void => {
+        set({ categories, autoCategoryRules })
+        // Same invalidation as addCategory/updateCategory: colours are read
+        // through the range-expansion cache.
+        bumpRangeExpansionVersion()
+      },
+
       toggleCategoryFilter: (categoryId: string): void => {
         const current = get().selectedCategoryIds
         const index = current.indexOf(categoryId)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -278,6 +278,8 @@ export interface CalendarActions {
   addAutoCategoryRule: (rule: AutoCategoryRule) => void
   updateAutoCategoryRule: (id: string, updates: Partial<AutoCategoryRule>) => void
   deleteAutoCategoryRule: (id: string) => void
+  /** Replace both lists at once, as settings sync does after merging a remote payload. */
+  applySyncedCategories: (categories: Category[], autoCategoryRules: AutoCategoryRule[]) => void
   toggleCategoryFilter: (categoryId: string) => void
   setCurrentDate: (date: string) => void
   setCurrentView: (view: ViewType) => void


### PR DESCRIPTION
Fixes #155.

**Payload.** `SettingsSyncPayload` gains optional `categories` and `autoCategoryRules`, read from the calendar store. `SYNC_FORMAT_VERSION` stays at 1 on purpose: `deserializeSettings` refuses unknown versions, so bumping would stop sync dead for anyone on an older build, whereas an older build reading this payload just ignores the two extra keys. Going the other way, a payload from an older build has no lists, and `mergeCategories` treats that as "leave mine alone".

**Merge** (`mergeCategories`, new). Categories are keyed by name rather than id, because every device mints its own: calendar sync creates an unseen `CATEGORIES` value as a new category with a fresh UUID and a random colour. So:

- a name both sides have takes the remote colour, keeps the local id
- a name only the remote has is added
- a name only the local side has is kept

The last one is deliberate. A deletion can't propagate through this channel anyway — the server's events still carry the name and the next calendar sync recreates the category — so dropping local extras would only lose colours. Auto-category rules reference a category by id, so each remote rule is re-pointed through the name at the local id (unresolvable ones are dropped) and rules merge by their own id, remote copy winning. When nothing differs the function returns the same `local` object so the store isn't written and the range-expansion cache isn't bumped on every post-sync pull.

**Apply.** The merge+apply was copy-pasted in three places (`useSettingsSync.pull`, and the account-add and post-sync blocks in `useCalDAV.ts`). They now call one `applyRemotePayload`, which updates the settings store as before and the calendar store through a new `applySyncedCategories` action (same invalidation as `addCategory`). Conflict resolution in each place is unchanged. Push stays manual, as for every other setting.

**Docs.** `CALINOSETTINGSSYNC.md`: payload example, the scope line that was wrong, and a short section on how the category merge differs from the scalar one.

**Tests.** `settingsSync.test.ts`: serialize includes the lists, deserialize without them, six `mergeCategories` cases (absent, unchanged, colour-by-name, add/keep, rule remap, rule replace + orphan drop), two `applyRemotePayload` cases. The existing pull test in `useSettingsSync.test.ts` now also asserts the lists land in the calendar store. The existing cross-device Playwright test in `settings-sync.spec.ts` seeds a category and a rule on the mock server and checks both show in Settings → Categories after enabling sync; it fails on main. Full vitest suite (5233) passes; settings-sync / calendar-sync / categories / incremental-sync specs pass in Chromium.
