### PR TITLE
fix(agenda): read a task's due time from dueDate, not from start

### DIFF
--- a/e2e/agenda.spec.ts
+++ b/e2e/agenda.spec.ts
@@ -67,6 +67,31 @@ async function seedAgendaItems(page: Page): Promise<void> {
               completed: false,
               categories: ['Focus'],
             },
+            {
+              // A date-only task after a drag: the handlers rewrite `start` as
+              // a UTC instant (this is local midnight for UTC+10) while
+              // `dueDate` and `isAllDay` stay as the form saved them.
+              id: 'agenda-dragged',
+              title: 'Agenda dragged task',
+              type: 'task',
+              start: new Date(`${today}T00:00:00+10:00`).toISOString(),
+              end: new Date(`${today}T23:59:59+10:00`).toISOString(),
+              dueDate: today,
+              isAllDay: true,
+              calendarId: 'default',
+              completed: false,
+            },
+            {
+              id: 'agenda-timed',
+              title: 'Agenda timed task',
+              type: 'task',
+              start: `${today}T15:30:00`,
+              end: `${today}T15:30:00`,
+              dueDate: `${today}T15:30:00`,
+              isAllDay: false,
+              calendarId: 'default',
+              completed: false,
+            },
           ],
         }
         localStorage.setItem(calendarKey, JSON.stringify(parsed))
@@ -235,6 +260,27 @@ test('agenda colours a task row by its category like an event row', async ({ pag
     .first()
   await expect(eventBar).toHaveCSS('background-color', 'rgb(59, 130, 246)')
   await expect(taskBar).toHaveCSS('background-color', 'rgb(59, 130, 246)')
+})
+
+test("agenda reads a task's due time from dueDate, not from start", async ({ page }) => {
+  await clearState(page)
+  await seedAgendaItems(page)
+  await page.goto('/agenda')
+
+  const today = localDate()
+  await expect(page.locator(`[data-date="${today}"]`)).toBeVisible()
+
+  const taskTime = (title: string) =>
+    page
+      .locator('[data-component="agenda-task"]')
+      .filter({ hasText: title })
+      .locator('[class*="agendaTaskTime"]')
+
+  // Date-only stays "Due" however `start` has been rewritten.
+  await expect(taskTime('Agenda dragged task')).toHaveText('Due')
+  await expect(taskTime('Agenda task')).toHaveText('Due')
+  // A real due time still shows.
+  await expect(taskTime('Agenda timed task')).toHaveText(/3:30|15:30/)
 })
 
 test('agenda collapses consecutive empty dates into a free-range row', async ({ page }) => {

--- a/src/features/calendar/components/AgendaView.tsx
+++ b/src/features/calendar/components/AgendaView.tsx
@@ -34,7 +34,7 @@ import {
 } from '@/lib/datetime'
 import { useTranslation } from 'react-i18next'
 import { safeCalDAVUpdate } from '@/lib/caldavHelpers'
-import { extractOriginalEventId } from '@/lib/events'
+import { extractOriginalEventId, hasDueTime } from '@/lib/events'
 import { LocationLink } from './LocationLink'
 import { useDateChangeMotion } from '@/hooks/useDateChangeMotion'
 import { useTaskContextMenuItems } from '../hooks/useTaskContextMenuItems'
@@ -770,13 +770,17 @@ export function AgendaView({ embedded = false }: { embedded?: boolean } = {}): J
                                         >
                                           <div className={styles.agendaTaskMain}>
                                             <span className={styles.agendaTaskTime}>
-                                              {event.start.includes('T00:00')
-                                                ? t('surface.agendaDue')
-                                                : formatEventTime(
-                                                    event.start,
+                                              {/* Off dueDate/isAllDay, as the month pill
+                                                  and the form are: `start` is rewritten
+                                                  as a UTC instant by a drag, so a string
+                                                  check on it only held in UTC. */}
+                                              {hasDueTime(event) && event.dueDate
+                                                ? formatEventTime(
+                                                    event.dueDate,
                                                     event.timezone,
                                                     timeFormat
-                                                  )}
+                                                  )
+                                                : t('surface.agendaDue')}
                                             </span>
                                             <button
                                               type="button"


### PR DESCRIPTION
Fixes #158.

The agenda's task row picked "Due" vs a time with `event.start.includes('T00:00')`. Both drag handlers (month grid and agenda) write `start` as `toISOString()`, so a date-only task that started life as `2026-09-13T00:00:00` becomes `2026-09-12T14:00:00.000Z` for anyone in UTC+10 and the check fails; the agenda then formats local midnight. `dueDate` and `isAllDay` aren't touched by a drag, which is why the form still shows "Date only".

The row now uses `hasDueTime()` from `lib/events.ts` and formats `dueDate`, the same as the month-view pill and the form. Tasks without a `dueDate` never reach the agenda (they're filtered before render), so there's no fallback to worry about.

I've left the drag handlers alone: `start` being a UTC instant is consistent with how every other path treats it via `toEventInstant`, and the bug was the display keying off the wrong field, not the stored value.

`e2e/agenda.spec.ts`: the seed gains a task in the shape a drag leaves (UTC `start`, date-only `dueDate`, `isAllDay: true`) and a timed task, and one new test asserts the former reads "Due" and the latter its time. On main the first assertion gets `00:00`. AgendaView unit tests and the other agenda specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
