### PR TITLE
fix(agenda): list each subtask under its parent

### DIFF
--- a/e2e/agenda.spec.ts
+++ b/e2e/agenda.spec.ts
@@ -33,6 +33,31 @@ async function seedAgendaItems(page: Page): Promise<void> {
               categories: ['Focus'],
             },
             {
+              // Stored before its parent, so the day's start-time sort puts it
+              // first; the agenda has to move it under the parent regardless.
+              id: 'agenda-early-child',
+              title: 'Agenda early child',
+              type: 'task',
+              start: `${today}T00:00:00`,
+              end: `${today}T00:00:00`,
+              dueDate: today,
+              isAllDay: true,
+              calendarId: 'default',
+              parentTaskId: 'agenda-late-parent',
+              completed: false,
+            },
+            {
+              id: 'agenda-late-parent',
+              title: 'Agenda late parent',
+              type: 'task',
+              start: `${today}T00:00:00`,
+              end: `${today}T00:00:00`,
+              dueDate: today,
+              isAllDay: true,
+              calendarId: 'default',
+              completed: false,
+            },
+            {
               id: 'agenda-parent',
               title: 'Agenda parent',
               type: 'task',
@@ -212,6 +237,29 @@ test('agenda indents subtasks and moves tasks and events between days', async ({
       agendaEvent.evaluate((element) => getComputedStyle(element.parentElement as Element).overflow)
     )
     .toBe('visible')
+})
+
+test('agenda lists a subtask under its parent even when it sorts first', async ({ page }) => {
+  await clearState(page)
+  await seedAgendaItems(page)
+  await page.goto('/agenda')
+
+  const today = localDate()
+  const day = page.locator(`[data-date="${today}"]`)
+  await expect(day).toBeVisible()
+
+  const titles = await day
+    .locator('[data-component="agenda-task"] [class*="agendaTaskTitle"]')
+    .allTextContents()
+  const parentAt = titles.indexOf('Agenda late parent')
+  expect(parentAt).toBeGreaterThanOrEqual(0)
+  expect(titles[parentAt + 1]).toBe('Agenda early child')
+  await expect(
+    day
+      .locator('[data-component="agenda-task"]')
+      .filter({ hasText: 'Agenda early child' })
+      .locator('[data-task-depth]')
+  ).toHaveAttribute('data-task-depth', '1')
 })
 
 test('agenda colours a task row by its category like an event row', async ({ page }) => {

--- a/src/features/calendar/components/AgendaView.tsx
+++ b/src/features/calendar/components/AgendaView.tsx
@@ -48,6 +48,46 @@ interface EventWithDate {
   date: Date
 }
 
+/**
+ * Put each subtask directly under its parent, the way the tasks page lists
+ * them. The day's sort is by start time, which knows nothing about the tree,
+ * so a subtask that happened to be created first came out above its parent —
+ * indented under whatever row sat above it. A task whose parent is due on a
+ * different day has nothing here to sit under and keeps its sorted place.
+ */
+function nestSubtasksUnderParents(items: EventWithDate[]): EventWithDate[] {
+  const taskIds = new Set<string>()
+  for (const item of items) if (item.event.type === 'task') taskIds.add(item.event.id)
+  const parentOf = (item: EventWithDate): string | undefined => {
+    const parentId = item.event.type === 'task' ? item.event.parentTaskId : undefined
+    return parentId && taskIds.has(parentId) ? parentId : undefined
+  }
+
+  const childrenByParent = new Map<string, EventWithDate[]>()
+  for (const item of items) {
+    const parentId = parentOf(item)
+    if (!parentId) continue
+    const siblings = childrenByParent.get(parentId) ?? []
+    siblings.push(item)
+    childrenByParent.set(parentId, siblings)
+  }
+  if (childrenByParent.size === 0) return items
+
+  const ordered: EventWithDate[] = []
+  const placed = new Set<string>()
+  const place = (item: EventWithDate): void => {
+    if (placed.has(item.event.id)) return
+    placed.add(item.event.id)
+    ordered.push(item)
+    for (const child of childrenByParent.get(item.event.id) ?? []) place(child)
+  }
+  for (const item of items) if (!parentOf(item)) place(item)
+  // Malformed data can make a cycle with no root on this day; nothing is
+  // allowed to disappear because of it.
+  for (const item of items) place(item)
+  return ordered
+}
+
 interface DayGroup {
   type: 'day' | 'skip'
   days: Date[]
@@ -488,7 +528,9 @@ export function AgendaView({ embedded = false }: { embedded?: boolean } = {}): J
       )
       eventMap.set(
         dateKey,
-        arr.filter(({ event }) => event.type !== 'task' || visibleTaskIds.has(event.id))
+        nestSubtasksUnderParents(
+          arr.filter(({ event }) => event.type !== 'task' || visibleTaskIds.has(event.id))
+        )
       )
     })
 


### PR DESCRIPTION
Fixes #160.

Adds `nestSubtasksUnderParents` to `AgendaView.tsx`, applied per day after the existing sort and the collapsed-ancestor filter. It's the same shape as `appendTask` on the tasks page: walk the day's items in sorted order, emit each root (any event, or a task whose parent isn't on this day) followed by its children, recursively. Children keep their sorted order among themselves. Days with no parent/child pair on them return the array untouched. A cycle with no root on the day (malformed data) falls through to a final pass so nothing vanishes.

Left as-is: the indent depth is still the global one from `taskDepthById`, so a child whose parent is due on another day still shows indented on its own day. That's how it behaved before and how the month view marks subtasks; I didn't want to fold a second behaviour change into this.

`e2e/agenda.spec.ts`: the seed gains a parent/child pair stored child-first, and one new test asserts the parent row is immediately followed by the child with depth 1. On main it gets "Agenda parent" in that slot. AgendaView unit tests and the other agenda specs pass. (The `moves tasks and events between days` drag test in that file fails on untouched main for me, as noted on #156.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
